### PR TITLE
First tokenizer steps

### DIFF
--- a/lib/gettext/po/exceptions.ex
+++ b/lib/gettext/po/exceptions.ex
@@ -1,0 +1,23 @@
+defmodule Gettext.PO.SyntaxError do
+  defexception [:message]
+
+  def exception(opts) do
+    line    = Keyword.fetch!(opts, :line)
+    message = Keyword.fetch!(opts, :message)
+
+    msg = "invalid syntax on line #{line}: #{message}"
+    %__MODULE__{message: msg}
+  end
+end
+
+defmodule Gettext.PO.TokenMissingError do
+  defexception [:message]
+
+  def exception(opts) do
+    line    = Keyword.fetch!(opts, :line)
+    token = Keyword.fetch!(opts, :token)
+
+    msg = "missing token #{token} on line #{line}"
+    %__MODULE__{message: msg}
+  end
+end

--- a/lib/gettext/po/tokenizer.ex
+++ b/lib/gettext/po/tokenizer.ex
@@ -1,0 +1,97 @@
+defmodule Gettext.PO.Tokenizer do
+  @moduledoc false
+
+  # This module is responsible for turning a chunk of text (a string) into a
+  # list of tokens. For what "token" means, see the docs for `tokenize/1`.
+
+  alias Gettext.PO.SyntaxError
+  alias Gettext.PO.TokenMissingError
+
+  @keywords ~w(msgid msgstr)
+
+  @whitespace [?\n, ?\t, ?\r, ?\s]
+  @whitespace_no_nl [?\t, ?\r, ?\s]
+  @escapable_chars [?", ?n, ?t, ?\\]
+
+  @doc """
+  Converts a string into a list of tokens.
+
+  A "token" is a three elements tuple formed by:
+
+    * the type of the token (an atom like `:keyword` or `:string`)
+    * the line the token is at
+    * the value of the token
+
+  Some examples of tokens are:
+
+    * `{:keyword, 33, :msgid}`
+    * `{:string, 6, "foo"}`
+
+  """
+  def tokenize(str) do
+    tokenize_line(str, 1, [])
+  end
+
+  # Converts the first line in `str` into a list of tokens and then moves on to
+  # the next line.
+  defp tokenize_line(str, line, acc)
+
+  # Go to the next line.
+  defp tokenize_line(<<?\n, rest :: binary>>, line, acc) do
+    tokenize_line(rest, line + 1, acc)
+  end
+
+  # Skip whitespace.
+  defp tokenize_line(<<char, rest :: binary>>, line, acc) when char in @whitespace_no_nl do
+    tokenize_line(rest, line, acc)
+  end
+
+  # Keywords.
+  for kw <- @keywords do
+    defp tokenize_line(unquote(kw) <> <<char, rest :: binary>>, line, acc)
+        when char in unquote(@whitespace) do
+      acc = [{:keyword, line, unquote(String.to_atom(kw))}|acc]
+      tokenize_line(rest, line, acc)
+    end
+
+    defp tokenize_line(unquote(kw) <> _rest, line, _acc) do
+      raise(SyntaxError, message: "no space after '#{unquote(kw)}'", line: line)
+    end
+  end
+
+  # String start.
+  defp tokenize_line(<<?", rest :: binary>>, line, acc) do
+    {str, rest} = tokenize_string(rest, line, "")
+    tokenize_line(rest, line, [{:string, line, str}|acc])
+  end
+
+  # End of file.
+  defp tokenize_line(<<>>, _line, acc) do
+    Enum.reverse acc
+  end
+
+  # Parses the double-quotes-delimited string `str` into a single `{:string,
+  # line, contents}` token. Note that `str` doesn't start with a double quote
+  # (since that was needed to identify the start of a string). Returns a tuple
+  # with the contents of the string and the rest of the original `str` (note
+  # that the rest  of the original string doesn't include the closing double
+  # quote).
+  defp tokenize_string(str, line, acc)
+
+  defp tokenize_string(<<?", rest :: binary>>, _line, acc),
+    do: {acc, rest}
+  defp tokenize_string(<<?\\, ?n, rest :: binary>>, line, acc),
+    do: tokenize_string(rest, line, <<acc :: binary, ?\n>>)
+  defp tokenize_string(<<?\\, ?t, rest :: binary>>, line, acc),
+    do: tokenize_string(rest, line, <<acc :: binary, ?\t>>)
+  defp tokenize_string(<<?\\, ?", rest :: binary>>, line, acc),
+    do: tokenize_string(rest, line, <<acc :: binary, ?">>)
+  defp tokenize_string(<<?\\, ?\\, rest :: binary>>, line, acc),
+    do: tokenize_string(rest, line, <<acc :: binary, ?\\>>)
+  defp tokenize_string(<<?\n, _rest :: binary>>, line, _acc),
+    do: raise(SyntaxError, line: line, message: "newline in string")
+  defp tokenize_string(<<char, rest :: binary>>, line, acc),
+    do: tokenize_string(rest, line, <<acc :: binary, char>>)
+  defp tokenize_string(<<>>, line, _acc),
+    do: raise(TokenMissingError, line: line, token: ~s("))
+end

--- a/lib/gettext/po/tokenizer.ex
+++ b/lib/gettext/po/tokenizer.ex
@@ -4,6 +4,10 @@ defmodule Gettext.PO.Tokenizer do
   # This module is responsible for turning a chunk of text (a string) into a
   # list of tokens. For what "token" means, see the docs for `tokenize/1`.
 
+  @type token ::
+    {:keyword, pos_integer, atom} |
+    {:string, pos_integer, binary}
+
   alias Gettext.PO.SyntaxError
   alias Gettext.PO.TokenMissingError
 
@@ -28,12 +32,14 @@ defmodule Gettext.PO.Tokenizer do
     * `{:string, 6, "foo"}`
 
   """
+  @spec tokenize(binary) :: [token]
   def tokenize(str) do
     tokenize_line(str, 1, [])
   end
 
   # Converts the first line in `str` into a list of tokens and then moves on to
   # the next line.
+  @spec tokenize_line(binary, pos_integer, [token]) :: [token]
   defp tokenize_line(str, line, acc)
 
   # Go to the next line.
@@ -74,8 +80,9 @@ defmodule Gettext.PO.Tokenizer do
   # line, contents}` token. Note that `str` doesn't start with a double quote
   # (since that was needed to identify the start of a string). Returns a tuple
   # with the contents of the string and the rest of the original `str` (note
-  # that the rest  of the original string doesn't include the closing double
+  # that the rest of the original string doesn't include the closing double
   # quote).
+  @spec tokenize_string(binary, pos_integer, binary) :: {token, binary}
   defp tokenize_string(str, line, acc)
 
   defp tokenize_string(<<?", rest :: binary>>, _line, acc),

--- a/test/gettext/po/tokenizer_test.exs
+++ b/test/gettext/po/tokenizer_test.exs
@@ -37,6 +37,14 @@ defmodule Gettext.PO.TokenizerTest do
   test "escape characters in strings" do
     str = ~S("foo,\nbar\tbaz\\")
     assert tokenize(str) == [{:string, 1, "foo,\nbar\tbaz\\"}]
+
+    str = ~S("fo\ø")
+    msg = "invalid syntax on line 1: unsupported escape code"
+    assert_raise SyntaxError, msg, fn -> tokenize(str) end
+
+    str = ~S("\ foo")
+    msg = "invalid syntax on line 1: unsupported escape code"
+    assert_raise SyntaxError, msg, fn -> tokenize(str) end
   end
 
   test "strings on multiple lines" do

--- a/test/gettext/po/tokenizer_test.exs
+++ b/test/gettext/po/tokenizer_test.exs
@@ -90,4 +90,34 @@ defmodule Gettext.PO.TokenizerTest do
       {:string, 2, "bar"},
     ]
   end
+
+  test "single-line comments are ignored" do
+    str = "# Single-line comment"
+    assert tokenize(str) == []
+
+    str = "#; Single-line non-whitespace comment"
+    assert tokenize(str) == []
+
+    str = "\t\t  # A comment"
+    assert tokenize(str) == []
+  end
+
+  test "multi-line comments are ignored" do
+    str = ~S"""
+    # Multiline comment
+      #, badly indented,
+      #: with weird chåracters
+    """
+    assert tokenize(str) == []
+
+    str = ~S"""
+    # Multiline comment with
+    msgid "a string"
+    # in it.
+    """
+    assert tokenize(str) == [
+      {:keyword, 2, :msgid},
+      {:string, 2, "a string"},
+    ]
+  end
 end

--- a/test/gettext/po/tokenizer_test.exs
+++ b/test/gettext/po/tokenizer_test.exs
@@ -1,0 +1,85 @@
+defmodule Gettext.PO.TokenizerTest do
+  use ExUnit.Case, async: true
+
+  import Gettext.PO.Tokenizer, only: [tokenize: 1]
+  alias Gettext.PO.SyntaxError
+  alias Gettext.PO.TokenMissingError
+
+  test "keywords" do
+    str = "msgid msgstr "
+    assert tokenize(str) == [
+      {:keyword, 1, :msgid},
+      {:keyword, 1, :msgstr},
+    ]
+
+    str = "    msgid      msgstr  "
+    assert tokenize(str) == [
+      {:keyword, 1, :msgid},
+      {:keyword, 1, :msgstr},
+    ]
+  end
+
+  test "keywords must be followed by a space" do
+    str = ~s(msgid"foo")
+    msg = "invalid syntax on line 1: no space after 'msgid'"
+    assert_raise SyntaxError, msg, fn -> tokenize(str) end
+
+    str = ~s(msgstr"foo")
+    msg = "invalid syntax on line 1: no space after 'msgstr'"
+    assert_raise SyntaxError, msg, fn -> tokenize(str) end
+  end
+
+  test "single simple string" do
+    str = ~s("foo bar")
+    assert tokenize(str) == [{:string, 1, "foo bar"}]
+  end
+
+  test "escape characters in strings" do
+    str = ~S("foo,\nbar\tbaz\\")
+    assert tokenize(str) == [{:string, 1, "foo,\nbar\tbaz\\"}]
+  end
+
+  test "strings on multiple lines" do
+    str = ~S"""
+    "foo"
+      "bar with \"quotes\""
+          "bong"
+    """
+
+    assert tokenize(str) == [
+      {:string, 1, "foo"},
+      {:string, 2, "bar with \"quotes\""},
+      {:string, 3, "bong"},
+    ]
+  end
+
+  test "no newlines are allowed in strings" do
+    str = ~S"""
+    "foo
+    bar"
+    """
+
+    msg = "invalid syntax on line 1: newline in string"
+    assert_raise SyntaxError, msg, fn -> tokenize(str) end
+  end
+
+  test "strings must have a terminator" do
+    str = ~s("foo)
+    msg = ~s(missing token " on line 1)
+    assert_raise TokenMissingError, msg, fn -> tokenize(str) end
+  end
+
+  test "tokens know on what line they are" do
+    str = ~S"""
+    msgid "foo"
+    msgstr "bar"
+    """
+
+    assert tokenize(str) == [
+      {:keyword, 1, :msgid},
+      {:string, 1, "foo"},
+      {:keyword, 2, :msgstr},
+      {:string, 2, "bar"},
+    ]
+  end
+end


### PR DESCRIPTION
I implemented a first (poor) draft of the tokenizer which only supports tokenizing strings and the `msgid` and `msgstr` keywords. I'm opening a PR this soon so that I know if I'm on the right track.

@josevalim and I discussed tokenizing and parsing on IRC. We were thinking about whether to roll out both a handwritten tokenizer and a handwritten parser or to write a tokenizer and than using with `yecc` (like Elixir).

As far as I looked into `.po` files, the grammar seems very simple. This means that we may be able to use a simple handwritten parser. Let's hear what everybody else has to say :).