### PR TITLE
Errors not exceptions

### DIFF
--- a/lib/gettext/po/exceptions.ex
+++ b/lib/gettext/po/exceptions.ex
@@ -9,15 +9,3 @@ defmodule Gettext.PO.SyntaxError do
     %__MODULE__{message: msg}
   end
 end
-
-defmodule Gettext.PO.TokenMissingError do
-  defexception [:message]
-
-  def exception(opts) do
-    line    = Keyword.fetch!(opts, :line)
-    token = Keyword.fetch!(opts, :token)
-
-    msg = "missing token #{token} on line #{line}"
-    %__MODULE__{message: msg}
-  end
-end

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -3,7 +3,6 @@ defmodule Gettext.PO.ParserTest do
 
   alias Gettext.PO.Parser
   alias Gettext.PO.Translation
-  alias Gettext.PO.SyntaxError
 
   test "parse/1 with single strings" do
     parsed = Parser.parse([
@@ -11,7 +10,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "ciao"}
     ])
 
-    assert parsed == [%Translation{msgid: "hello", msgstr: "ciao"}]
+    assert parsed == {:ok, [%Translation{msgid: "hello", msgstr: "ciao"}]}
   end
 
   test "parse/1 with multiple concatenated strings" do
@@ -20,7 +19,9 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "ciao"}, {:str, 3, " mondo"}
     ])
 
-    assert parsed == [%Translation{msgid: "hello world", msgstr: "ciao mondo"}]
+    assert parsed == {:ok, [
+      %Translation{msgid: "hello world", msgstr: "ciao mondo"}
+    ]}
   end
 
   test "parse/1 with multiple translations" do
@@ -31,10 +32,10 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 4}, {:str, 4, "parola"},
     ])
 
-    assert parsed == [
+    assert parsed == {:ok, [
       %Translation{msgid: "hello", msgstr: "ciao"},
       %Translation{msgid: "word", msgstr: "parola"},
-    ]
+    ]}
   end
 
   test "parse/1 with unicode characters in the strings" do
@@ -43,16 +44,14 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "bårπ"},
     ])
 
-    assert parsed == [%Translation{msgid: "føø", msgstr: "bårπ"}]
+    assert parsed == {:ok, [%Translation{msgid: "føø", msgstr: "bårπ"}]}
   end
 
   test "syntax error when there is no 'msgid'" do
-    assert_raise SyntaxError, fn ->
-      Parser.parse [{:msgstr, 1}, {:str, 1, "foo"}]
-    end
+    parsed = Parser.parse [{:msgstr, 1}, {:str, 1, "foo"}]
+    assert {:error, 1, _} = parsed
 
-    assert_raise SyntaxError, fn ->
-      Parser.parse [{:str, 1, "foo"}]
-    end
+    parsed = Parser.parse [{:str, 1, "foo"}]
+    assert {:error, 1, _} = parsed
   end
 end


### PR DESCRIPTION
I think I could've pushed this right away instead of opening a PR, but a second opinion is always extremely helpful.

I just removed all the `raise` statements from both the parser and the tokenizer, making them return `{:ok, stuff} | {:error, line, reason}` tuples instead. I kind of stole this from EEx.

This way, we can control errors better: for example, when parsing a file instead of a string we can report the line **and the file** where the error occurred instead of the line only. Raising in the tokenizer/parser makes code a little bit harder to control, since every function call could fail badly and that may not always be what we want.

If you're ok with this, I'll merge :). Thanks!