### PR TITLE
Interpolation

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -55,7 +55,16 @@ defmodule Gettext do
       @before_compile Gettext
 
       def lgettext(locale, domain, msgid, bindings \\ %{})
+
+      def lgettext(locale, domain, msgid, bindings) when is_list(bindings) do
+        lgettext(locale, domain, msgid, Enum.into(bindings, %{}))
+      end
+
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings \\ %{})
+
+      def lngettext(locale, domain, msgid, msgid_plural, n, bindings) when is_list(bindings) do
+        lngettext(locale, domain, msgid, msgid_plural, n, Enum.into(bindings, %{}))
+      end
     end
   end
 
@@ -78,7 +87,7 @@ defmodule Gettext do
       end
 
       def lngettext(_, _, msgid, msgid_plural, n, bindings) do
-        str = if n == 1, do: msgid, else: msgid_plural
+        str      = if n == 1, do: msgid, else: msgid_plural
         bindings = Map.put(bindings, :count, n)
 
         case Gettext.Interpolation.interpolate(str, bindings) do
@@ -147,18 +156,12 @@ defmodule Gettext do
     interpolation = compile_interpolation(str)
 
     quote do
-      bindings = var!(bindings)
-
-      if is_list(bindings) do
-        bindings = Enum.into bindings, %{}
-      end
-
-      case bindings do
+      case var!(bindings) do
         unquote(match) ->
           {:ok, unquote(interpolation)}
         _ ->
           keys = unquote(keys)
-          {:error, Gettext.Interpolation.missing_interpolation_keys(bindings, keys)}
+          {:error, Gettext.Interpolation.missing_interpolation_keys(var!(bindings), keys)}
       end
     end
   end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -136,7 +136,7 @@ defmodule Gettext do
     quote do
       def lngettext(unquote(locale), unquote(domain), unquote(t.msgid), unquote(t.msgid_plural), n, bindings) do
         plural_form    = unquote(@plural_forms).plural(unquote(locale), n)
-        var!(bindings) = Dict.put(bindings, :count, n)
+        var!(bindings) = Map.put(bindings, :count, n)
 
         case plural_form, do: unquote(clauses)
       end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -46,6 +46,7 @@ defmodule Gettext do
   alias Gettext.Interpolation
 
   @default_priv "priv/gettext"
+  @pluralizer Application.get_env(:gettext, :plural_forms, Gettext.Plural)
 
   @doc false
   defmacro __using__(opts) do
@@ -154,7 +155,7 @@ defmodule Gettext do
         if is_list(bindings) do
           bindings = Enum.into bindings, %{}
         end
-        form = Gettext.Plural.plural(unquote(locale), n)
+        form = unquote(@pluralizer).plural(unquote(locale), n)
         bindings = Map.put(bindings, :count, n)
         q = Map.fetch!(unquote(Macro.escape(forms)), form)
         {res, _} = Code.eval_quoted(q, bindings: bindings)

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -46,7 +46,7 @@ defmodule Gettext do
   alias Gettext.Interpolation
 
   @default_priv "priv/gettext"
-  @pluralizer Application.get_env(:gettext, :plural_forms, Gettext.Plural)
+  @plural_forms Application.get_env(:gettext, :plural_forms, Gettext.Plural)
 
   @doc false
   defmacro __using__(opts) do
@@ -126,7 +126,7 @@ defmodule Gettext do
 
     quote do
       def lngettext(unquote(locale), unquote(domain), unquote(t.msgid), unquote(t.msgid_plural), n, bindings) do
-        plural_form = unquote(@pluralizer).plural(unquote(locale), n)
+        plural_form = unquote(@plural_forms).plural(unquote(locale), n)
         bindings    = Dict.put(bindings, :count, n)
 
         unquote(Macro.escape(compiled_plural_forms))

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -20,7 +20,7 @@ defmodule Gettext.Interpolation do
 
   ## Examples
 
-      iex> to_interpolatable("Hello %{name}, you have %{count} unread messages")
+      iex> Gettext.Interpolation.to_interpolatable("Hello %{name}, you have %{count} unread messages")
       ["Hello ", :name, ", you have ", :count, " unread messages"]
 
   """
@@ -42,11 +42,11 @@ defmodule Gettext.Interpolation do
 
   ## Examples
 
-      iex> missing_interpolation_keys(%{foo: 1}, [:foo, :bar, :baz]
+      iex> Gettext.Interpolation.missing_interpolation_keys %{foo: 1}, [:foo, :bar, :baz]
       "missing interpolation keys: bar, baz"
 
   """
-  @spec missing_interpolation_keys(Dict.t, [atom]) :: binary
+  @spec missing_interpolation_keys(Map.t, [atom]) :: binary
   def missing_interpolation_keys(bindings, required) do
     present = Dict.keys(bindings)
     missing = required -- present
@@ -66,10 +66,10 @@ defmodule Gettext.Interpolation do
 
   ## Examples
 
-      iex> keys("Hey %{name}, I'm %{other_name}")
+      iex> Gettext.Interpolation.keys("Hey %{name}, I'm %{other_name}")
       [:name, :other_name]
 
-      iex> keys(["Hello ", :name, "!"])
+      iex> Gettext.Interpolation.keys(["Hello ", :name, "!"])
       [:name]
 
   """
@@ -89,22 +89,22 @@ defmodule Gettext.Interpolation do
 
   ## Examples
 
-      iex> interpolate "Hello %{name}", name: "José"
+      iex> Gettext.Interpolation.interpolate "Hello %{name}", %{name: "José"}
       {:ok, "Hello José"}
-      iex> interpolate "%{count} errors", %{name: "Jane"}
+      iex> Gettext.Interpolation.interpolate "%{count} errors", %{name: "Jane"}
       {:error, "missing interpolation keys: count"}
 
   """
-  @spec interpolate(binary, Dict.t) :: {:ok, binary} | {:error, binary}
+  @spec interpolate(binary, Map.t) :: {:ok, binary} | {:error, binary}
   def interpolate(str, bindings) do
     segments = to_interpolatable(str)
     keys     = keys(segments)
 
-    if keys -- Dict.keys(bindings) != [] do
+    if keys -- Map.keys(bindings) != [] do
       {:error, missing_interpolation_keys(bindings, keys)}
     else
       interpolated = Enum.map_join segments, "", fn
-        key when is_atom(key) -> Dict.fetch!(bindings, key)
+        key when is_atom(key) -> Map.fetch!(bindings, key)
         other                 -> other
       end
       {:ok, interpolated}

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -90,16 +90,16 @@ defmodule Gettext.Interpolation do
   """
   @spec interpolate(binary, Dict.t) :: {:ok, binary} | {:error, binary}
   def interpolate(str, bindings) do
-    try do
-      s = Enum.map_join to_interpolatable(str), "", fn
+    keys = keys(str)
+
+    if keys -- Dict.keys(bindings) != [] do
+      {:error, missing_interpolation_keys(bindings, keys)}
+    else
+      interpolated = Enum.map_join to_interpolatable(str), "", fn
         key when is_atom(key) -> Dict.fetch!(bindings, key)
         other                 -> other
       end
-      {:ok, s}
-    rescue
-      KeyError ->
-        required = keys(str)
-        {:error, missing_interpolation_keys(bindings, required)}
+      {:ok, interpolated}
     end
   end
 end

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -1,4 +1,12 @@
 defmodule Gettext.Interpolation do
+  @interpolation_regex ~r/
+    (?<left>)  # Start, available through :left
+    %{         # Literal '%{'
+      [^}]+    # One or more non-} characters
+    }          # Literal '}'
+    (?<right>) # End, available through :right
+  /x
+
   defmodule BadInterpolationError do
     defexception [:message]
 
@@ -9,29 +17,37 @@ defmodule Gettext.Interpolation do
     end
   end
 
+  def to_interpolatable(str) do
+    split = Regex.split(@interpolation_regex, str, on: [:left, :right], trim: true)
+
+    Enum.map split, fn
+      "%{" <> rest -> rest |> String.rstrip(?}) |> String.to_atom
+      segment      -> segment
+    end
+  end
+
   def missing_interpolation_keys(bindings, required) do
     present = Dict.keys(bindings)
     missing = required -- present
     "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
   end
 
+  def bindings_in_string(str) do
+    str
+    |> to_interpolatable
+    |> Enum.filter(&is_atom/1)
+  end
+
   def interpolate(str, bindings) do
     try do
-      s = ~r/(?<head>)%{[^}]+}(?<tail>)/
-      |> Regex.split(str, on: [:head, :tail])
-      |> Enum.map_join("", fn
-        "%{" <> rest ->
-          key = rest |> String.rstrip(?}) |> String.to_atom
-          Dict.fetch!(bindings, key)
-        other ->
-          other
-      end)
+      s = Enum.map_join to_interpolatable(str), "", fn
+        key when is_atom(key) -> Dict.fetch!(bindings, key)
+        other                 -> other
+      end
       {:ok, s}
     rescue
       KeyError ->
-        required =
-          Regex.scan(~r/%{([^}]+)}/, str)
-          |> Enum.map(fn [_, b] -> String.to_atom(b) end)
+        required = bindings_in_string(str)
         {:error, missing_interpolation_keys(bindings, required)}
     end
   end

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -1,0 +1,38 @@
+defmodule Gettext.Interpolation do
+  defmodule BadInterpolationError do
+    defexception [:message]
+
+    def exception(opts) do
+      str = Keyword.fetch!(opts, :interpolation)
+      msg = "invalid interpolation: '#{str}'"
+      %__MODULE__{message: msg}
+    end
+  end
+
+  def missing_interpolation_keys(bindings, required) do
+    present = Dict.keys(bindings)
+    missing = required -- present
+    "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
+  end
+
+  def interpolate(str, bindings) do
+    try do
+      s = ~r/(?<head>)%{[^}]+}(?<tail>)/
+      |> Regex.split(str, on: [:head, :tail])
+      |> Enum.map_join("", fn
+        "%{" <> rest ->
+          key = rest |> String.rstrip(?}) |> String.to_atom
+          Dict.fetch!(bindings, key)
+        other ->
+          other
+      end)
+      {:ok, s}
+    rescue
+      KeyError ->
+        required =
+          Regex.scan(~r/%{([^}]+)}/, str)
+          |> Enum.map(fn [_, b] -> String.to_atom(b) end)
+        {:error, missing_interpolation_keys(bindings, required)}
+    end
+  end
+end

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -7,16 +7,6 @@ defmodule Gettext.Interpolation do
     (?<right>) # End, available through :right
   /x
 
-  defmodule BadInterpolationError do
-    defexception [:message]
-
-    def exception(opts) do
-      str = Keyword.fetch!(opts, :interpolation)
-      msg = "invalid interpolation: '#{str}'"
-      %__MODULE__{message: msg}
-    end
-  end
-
   def to_interpolatable(str) do
     split = Regex.split(@interpolation_regex, str, on: [:left, :right], trim: true)
 

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -1,4 +1,8 @@
 defmodule Gettext.Interpolation do
+  @moduledoc """
+  Provides facilities for working with interpolations.
+  """
+
   @interpolation_regex ~r/
     (?<left>)  # Start, available through :left
     %{         # Literal '%{'
@@ -7,6 +11,20 @@ defmodule Gettext.Interpolation do
     (?<right>) # End, available through :right
   /x
 
+  @doc """
+  Extracts interpolations from a given string.
+
+  This function extracts all interpolations in the form `%{interpolation}`
+  contained inside `str`, converts them to atoms and then returns a list of
+  string and interpolation keys.
+
+  ## Examples
+
+      iex> to_interpolatable("Hello %{name}, you have %{count} unread messages")
+      ["Hello ", :name, ", you have ", :count, " unread messages"]
+
+  """
+  @spec to_interpolatable(binary) :: [binary | atom]
   def to_interpolatable(str) do
     split = Regex.split(@interpolation_regex, str, on: [:left, :right], trim: true)
 
@@ -16,18 +34,61 @@ defmodule Gettext.Interpolation do
     end
   end
 
+  @doc """
+  Tells which `required` keys are missing in `bindings`.
+
+  Returns an error message which tells which keys in `required` don't appear in
+  `bindings`.
+
+  ## Examples
+
+      iex> missing_interpolation_keys(%{foo: 1}, [:foo, :bar, :baz]
+      "missing interpolation keys: bar, baz"
+
+  """
+  @spec missing_interpolation_keys(Dict.t, [atom]) :: binary
   def missing_interpolation_keys(bindings, required) do
     present = Dict.keys(bindings)
     missing = required -- present
     "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
   end
 
+  @doc """
+  Returns all the interpolation keys contained in `str`.
+
+  This function returns a list of all the interpolation keys (patterns in the
+  form `%{interpolation}`) contained in `str`.
+
+  ## Examples
+
+      iex> keys("Hey %{name}, I'm %{other_name}")
+      [:name, :other_name]
+
+  """
+  @spec keys(binary) :: [atom]
   def keys(str) do
     str
     |> to_interpolatable
     |> Enum.filter(&is_atom/1)
   end
 
+  @doc """
+  Dynimically interpolates `str` with the given `bindings`.
+
+  This function replaces all interpolations (like `%{this}`) inside `str` with
+  the keys contained in `bindings`. It returns `{:ok, str}` if all the
+  interpolation keys in `str` are present in `bindings`, `{:error, msg}`
+  otherwise.
+
+  ## Examples
+
+      iex> interpolate "Hello %{name}", name: "José"
+      {:ok, "Hello José"}
+      iex> interpolate "%{count} errors", %{name: "Jane"}
+      {:error, "missing interpolation keys: count"}
+
+  """
+  @spec interpolate(binary, Dict.t) :: {:ok, binary} | {:error, binary}
   def interpolate(str, bindings) do
     try do
       s = Enum.map_join to_interpolatable(str), "", fn

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -32,7 +32,7 @@ defmodule Gettext.Interpolation do
     "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
   end
 
-  def bindings_in_string(str) do
+  def keys(str) do
     str
     |> to_interpolatable
     |> Enum.filter(&is_atom/1)
@@ -47,7 +47,7 @@ defmodule Gettext.Interpolation do
       {:ok, s}
     rescue
       KeyError ->
-        required = bindings_in_string(str)
+        required = keys(str)
         {:error, missing_interpolation_keys(bindings, required)}
     end
   end

--- a/lib/gettext/po/tokenizer.ex
+++ b/lib/gettext/po/tokenizer.ex
@@ -4,10 +4,14 @@ defmodule Gettext.PO.Tokenizer do
   # This module is responsible for turning a chunk of text (a string) into a
   # list of tokens. For what "token" means, see the docs for `tokenize/1`.
 
+  @type line :: pos_integer
+
   @type token ::
-    {:str, pos_integer, binary} |
-    {:msgid, pos_integer} |
-    {:msgstr, pos_integer}
+    {:str, line, binary} |
+    {:plural_form, line, non_neg_integer} |
+    {:msgid, line} |
+    {:msgid_plural, line} |
+    {:msgstr, line}
 
   # In this list of keywords *the order matters* because a function clause is
   # generated for each keyword, and keywords have to be followed by whitespace.

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
@@ -1,0 +1,10 @@
+msgid "Hello %{name}"
+msgstr "Ciao %{name}"
+
+msgid "My name is %{name} and I'm %{age}"
+msgstr "Mi chiamo %{name} e ho %{age} anni"
+
+msgid "You have one message, %{name}"
+msgid_plural "You have %{count} messages, %{name}"
+msgstr[0] "Hai un messaggio, %{name}"
+msgstr[1] "Hai %{count} messaggi, %{name}"

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -1,5 +1,6 @@
 defmodule Gettext.InterpolationTest do
   use ExUnit.Case, async: true
+  doctest Gettext.Interpolation
   alias Gettext.Interpolation
 
   test "to_interpolatable/1" do
@@ -25,7 +26,7 @@ defmodule Gettext.InterpolationTest do
   end
 
   test "interpolate/2: successful cases" do
-    assert Interpolation.interpolate("Hello %{name}", name: "Alex")
+    assert Interpolation.interpolate("Hello %{name}", %{name: "Alex"})
            == {:ok, "Hello Alex"}
     assert Interpolation.interpolate("%{count} errors", %{count: 3})
            == {:ok, "3 errors"}
@@ -37,7 +38,7 @@ defmodule Gettext.InterpolationTest do
   end
 
   test "interpolate/2: unused bindings are ignored" do
-    assert Interpolation.interpolate("Hi %{name}", name: "Sandra", foo: "bar")
+    assert Interpolation.interpolate("Hi %{name}", %{name: "Sandra", foo: "bar"})
            == {:ok, "Hi Sandra"}
   end
 

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -2,6 +2,15 @@ defmodule Gettext.InterpolationTest do
   use ExUnit.Case, async: true
   alias Gettext.Interpolation
 
+  test "to_interpolatable/1" do
+    assert Interpolation.to_interpolatable("Hello %{name}")
+           == ["Hello ", :name]
+    assert Interpolation.to_interpolatable("%{foo}%{bar} %{baz}")
+           == [:foo, :bar, " ", :baz]
+    assert Interpolation.to_interpolatable("%{Your name} is cool!")
+           == [:"Your name", " is cool!"]
+  end
+
   test "missing_interpolation_keys/2" do
     bindings = %{
       foo: "foo",
@@ -30,5 +39,14 @@ defmodule Gettext.InterpolationTest do
   test "interpolate/2: unused bindings are ignored" do
     assert Interpolation.interpolate("Hi %{name}", name: "Sandra", foo: "bar")
            == {:ok, "Hi Sandra"}
+  end
+
+  test "bindings_in_string/1" do
+    assert Interpolation.bindings_in_string("Hello %{name}")
+           == [:name]
+    assert Interpolation.bindings_in_string("It's %{time} here in %{state}")
+           == [:time, :state]
+    assert Interpolation.bindings_in_string("Hi there %{your name}")
+           == [:"your name"]
   end
 end

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -41,12 +41,12 @@ defmodule Gettext.InterpolationTest do
            == {:ok, "Hi Sandra"}
   end
 
-  test "bindings_in_string/1" do
-    assert Interpolation.bindings_in_string("Hello %{name}")
+  test "keys/1" do
+    assert Interpolation.keys("Hello %{name}")
            == [:name]
-    assert Interpolation.bindings_in_string("It's %{time} here in %{state}")
+    assert Interpolation.keys("It's %{time} here in %{state}")
            == [:time, :state]
-    assert Interpolation.bindings_in_string("Hi there %{your name}")
+    assert Interpolation.keys("Hi there %{your name}")
            == [:"your name"]
   end
 end

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -1,0 +1,34 @@
+defmodule Gettext.InterpolationTest do
+  use ExUnit.Case, async: true
+  alias Gettext.Interpolation
+
+  test "missing_interpolation_keys/2" do
+    bindings = %{
+      foo: "foo",
+      bar: "baz",
+    }
+
+    assert Interpolation.missing_interpolation_keys(bindings, [:foo, :bar, :baz])
+           == "missing interpolation keys: baz"
+
+    assert Interpolation.missing_interpolation_keys(bindings, [:foo, :bar, :a, :b, :c])
+           == "missing interpolation keys: a, b, c"
+  end
+
+  test "interpolate/2: successful cases" do
+    assert Interpolation.interpolate("Hello %{name}", name: "Alex")
+           == {:ok, "Hello Alex"}
+    assert Interpolation.interpolate("%{count} errors", %{count: 3})
+           == {:ok, "3 errors"}
+  end
+
+  test "interpolate/2: missing bindings" do
+    assert Interpolation.interpolate("Hi %{name}", %{})
+           == {:error, "missing interpolation keys: name"}
+  end
+
+  test "interpolate/2: unused bindings are ignored" do
+    assert Interpolation.interpolate("Hi %{name}", name: "Sandra", foo: "bar")
+           == {:ok, "Hi Sandra"}
+  end
+end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -90,7 +90,7 @@ defmodule GettextTest do
            == {:ok, "Hai 0 messaggi, Jane"}
   end
 
-  test "when keys are missing in an interpolation, an error is returned" do
+  test "lgettext/4: error when keys are missing in an interpolation" do
     msgid = "My name is %{name} and I'm %{age}"
     assert Translator.lgettext("it", "interpolations", msgid, name: "José")
            == {:error, "missing interpolation keys: age"}
@@ -107,6 +107,17 @@ defmodule GettextTest do
 
     msgid = "Hello %{name}"
     assert Translator.lgettext("pl", "foo", msgid, %{})
+           == {:error, "missing interpolation keys: name"}
+  end
+
+  test "lngettext/6: error when keys are missing in an interpolation" do
+    msgid =  "You have one message, %{name}"
+    msgid_plural = "You have %{count} messages, %{name}"
+
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
+           == {:error, "missing interpolation keys: name"}
+
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6)
            == {:error, "missing interpolation keys: name"}
   end
 

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -55,8 +55,10 @@ defmodule GettextTest do
   end
 
   test "by default, non-found pluralized translation behave like regular translation" do
-    assert Translator.lngettext("it", "not a domain", "foo", "foos", 10)
+    assert Translator.lngettext("it", "not a domain", "foo", "foos", 1)
            == {:default, "foo"}
+    assert Translator.lngettext("it", "not a domain", "foo", "foos", 10)
+           == {:default, "foos"}
   end
 
   test "interpolation is supported by lgettext" do
@@ -86,5 +88,34 @@ defmodule GettextTest do
            == {:ok, "Hai un messaggio, Jane"}
     assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 0, %{name: "Jane"})
            == {:ok, "Hai 0 messaggi, Jane"}
+  end
+
+  test "when keys are missing in an interpolation, an error is returned" do
+    msgid = "My name is %{name} and I'm %{age}"
+    assert Translator.lgettext("it", "interpolations", msgid, name: "José")
+           == {:error, "missing interpolation keys: age"}
+  end
+
+  test "lgettext/4: interpolation works when a translation is missing" do
+    msgid = "Hello %{name}, missing translation!"
+    assert Translator.lgettext("pl", "foo", msgid, name: "Samantha")
+           == {:default, "Hello Samantha, missing translation!"}
+
+    msgid = "Hello world!"
+    assert Translator.lgettext("pl", "foo", msgid)
+           == {:default, "Hello world!"}
+
+    msgid = "Hello %{name}"
+    assert Translator.lgettext("pl", "foo", msgid, %{})
+           == {:error, "missing interpolation keys: name"}
+  end
+
+  test "lngettext/6: interpolation works when a translation is missing" do
+    msgid        = "One error"
+    msgid_plural = "%{count} errors"
+    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 1)
+           == {:default, "One error"}
+    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 9)
+           == {:default, "9 errors"}
   end
 end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -58,4 +58,33 @@ defmodule GettextTest do
     assert Translator.lngettext("it", "not a domain", "foo", "foos", 10)
            == {:default, "foo"}
   end
+
+  test "interpolation is supported by lgettext" do
+    assert Translator.lgettext("it", "interpolations", "Hello %{name}", name: "Jane")
+           == {:ok, "Ciao Jane"}
+
+    msgid = "My name is %{name} and I'm %{age}"
+    assert Translator.lgettext("it", "interpolations", msgid, name: "Meg", age: 33)
+           == {:ok, "Mi chiamo Meg e ho 33 anni"}
+
+    # A map of bindings is supported as well.
+    assert Translator.lgettext("it", "interpolations", "Hello %{name}", %{name: "Jane"})
+           == {:ok, "Ciao Jane"}
+  end
+
+  test "interpolation is supported by lngettext" do
+    msgid        = "There was an error"
+    msgid_plural = "There were %{count} errors"
+    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 1)
+           == {:ok, "C'è stato un errore"}
+    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 4)
+           == {:ok, "Ci sono stati 4 errori"}
+
+    msgid        = "You have one message, %{name}"
+    msgid_plural = "You have %{count} messages, %{name}"
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, name: "Jane")
+           == {:ok, "Hai un messaggio, Jane"}
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 0, %{name: "Jane"})
+           == {:ok, "Hai 0 messaggi, Jane"}
+  end
 end


### PR DESCRIPTION
Support for interpolation, yay!

This is by far the "dirtiest" code I had to write within gettext, but I had some trouble finding cleaner ways of doing things. One of the dirtiest things I did is using `Code.eval_quoted/2` ([here](https://github.com/whatyouhide/gettext/blob/interpolation/lib/gettext.ex#L134)), but I couldn't come up with a better way to do this. Another smelly thing is that I shared a variable (`bindings`) between macros, effectively making them *not* hygienic.

I'll wait for any (very welcome!) feedback or suggestions :). Thanks in advance!