### PR TITLE
Public API

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -87,4 +87,19 @@ defmodule Gettext do
   def gettext(backend, string, bindings \\ %{}) do
     dgettext(backend, "default", string, bindings)
   end
+
+  @spec dngettext(atom, binary, binary, binary, non_neg_integer, Map.t) :: binary
+  def dngettext(backend, domain, id, plural_id, n, bindings \\ %{}) do
+    case backend.lngettext(locale(), domain, id, plural_id, n, bindings) do
+      {atom, string} when atom in [:ok, :default] ->
+        string
+      {:error, error} ->
+        raise Gettext.Interpolation.MissingKeysError, error
+    end
+  end
+
+  @spec ngettext(atom, binary, binary, non_neg_integer, Map.t) :: binary
+  def ngettext(backend, id, plural_id, n, bindings \\ %{}) do
+    dngettext(backend, "default", id, plural_id, n, bindings)
+  end
 end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -43,8 +43,6 @@ defmodule Gettext do
 
   @type locale :: binary
 
-  @default_locale "en"
-
   @doc false
   defmacro __using__(opts) do
     quote do
@@ -73,7 +71,7 @@ defmodule Gettext do
     if locale = Process.get(__MODULE__) do
       locale
     else
-      default_locale = Application.get_env(:gettext, :default_locale, @default_locale)
+      default_locale = Application.get_env(:gettext, :default_locale)
       Process.put(__MODULE__, default_locale)
       default_locale
     end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -55,7 +55,15 @@ defmodule Gettext do
   end
 
   @spec locale() :: locale
-  def locale, do: Process.get(__MODULE__, @default_locale)
+  def locale do
+    if locale = Process.get(__MODULE__) do
+      locale
+    else
+      default_locale = Application.get_env(:gettext, :default_locale, @default_locale)
+      Process.put(__MODULE__, default_locale)
+      default_locale
+    end
+  end
 
   @spec locale(locale) :: nil
   def locale(locale) when is_binary(locale),

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -70,4 +70,21 @@ defmodule Gettext do
     do: Process.put(__MODULE__, locale)
   def locale(_locale),
     do: raise(ArgumentError, "locale/1 only accepts binary locales")
+
+  @spec dgettext(atom, binary, binary, Map.t) :: binary
+  def dgettext(backend, domain, string, bindings \\ %{}) do
+    case backend.lgettext(locale(), domain, string, bindings) do
+      {:ok, string} ->
+        string
+      {:default, string} ->
+        string
+      {:error, error} ->
+        raise Gettext.Interpolation.MissingKeysError, error
+    end
+  end
+
+  @spec gettext(atom, binary, Map.t) :: binary
+  def gettext(backend, string, bindings \\ %{}) do
+    dgettext(backend, "default", string, bindings)
+  end
 end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -43,6 +43,8 @@ defmodule Gettext do
 
   @type locale :: binary
 
+  @default_locale "en"
+
   @doc false
   defmacro __using__(opts) do
     quote do
@@ -53,7 +55,7 @@ defmodule Gettext do
   end
 
   @spec locale() :: locale
-  def locale, do: Process.get(__MODULE__, :en)
+  def locale, do: Process.get(__MODULE__, @default_locale)
 
   @spec locale(locale) :: nil
   def locale(locale) when is_binary(locale),

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -54,6 +54,20 @@ defmodule Gettext do
     end
   end
 
+  @doc """
+  Gets the locale for the current process.
+
+  This function returns the value of the locale for the current process. If
+  there is no locale for the current process, the default locale is set as the
+  locale for the current process and then returned. For more information on the
+  default locale, refer to the documentation of the `Gettext` module.
+
+  ## Examples
+
+      Gettext.locale()
+      #=> "en"
+
+  """
   @spec locale() :: locale
   def locale do
     if locale = Process.get(__MODULE__) do
@@ -65,6 +79,20 @@ defmodule Gettext do
     end
   end
 
+  @doc """
+  Sets the locale for the current process.
+
+  `locale` must be a string; if it's not, an `ArgumentError` exception is
+  raised.
+
+  ## Examples
+
+      Gettext.locale("pt_BR")
+      #=> nil
+      Gettext.locale
+      #=> "pt_BR"
+
+  """
   @spec locale(locale) :: nil
   def locale(locale) when is_binary(locale),
     do: Process.put(__MODULE__, locale)

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -106,7 +106,13 @@ defmodule Gettext do
     do: raise(ArgumentError, "locale/1 only accepts binary locales")
 
   @spec dgettext(atom, binary, binary, Map.t) :: binary
-  def dgettext(backend, domain, string, bindings \\ %{}) do
+  def dgettext(backend, domain, string, bindings \\ %{})
+
+  def dgettext(backend, domain, string, bindings) when is_list(bindings) do
+    dgettext(backend, domain, string, Enum.into(bindings, %{}))
+  end
+
+  def dgettext(backend, domain, string, bindings) do
     backend.lgettext(locale(), domain, string, bindings)
     |> handle_backend_result
   end
@@ -117,7 +123,13 @@ defmodule Gettext do
   end
 
   @spec dngettext(atom, binary, binary, binary, non_neg_integer, Map.t) :: binary
-  def dngettext(backend, domain, id, plural_id, n, bindings \\ %{}) do
+  def dngettext(backend, domain, id, plural_id, n, bindings \\ %{})
+
+  def dngettext(backend, domain, id, plural_id, n, bindings) when is_list(bindings) do
+    dngettext(backend, domain, id, plural_id, n, Enum.into(bindings, %{}))
+  end
+
+  def dngettext(backend, domain, id, plural_id, n, bindings) do
     backend.lngettext(locale(), domain, id, plural_id, n, bindings)
     |> handle_backend_result
   end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -41,6 +41,14 @@ defmodule Gettext do
 
   """
 
+  defmodule Error do
+    defexception [:message]
+
+    def exception(message) do
+      %__MODULE__{message: message}
+    end
+  end
+
   @type locale :: binary
 
   @doc false
@@ -122,5 +130,5 @@ defmodule Gettext do
   defp handle_backend_result({atom, string}) when atom in [:ok, :default],
     do: string
   defp handle_backend_result({:error, error}),
-    do: raise(Gettext.Interpolation.MissingKeysError, error)
+    do: raise(Error, error)
 end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -101,14 +101,8 @@ defmodule Gettext do
 
   @spec dgettext(atom, binary, binary, Map.t) :: binary
   def dgettext(backend, domain, string, bindings \\ %{}) do
-    case backend.lgettext(locale(), domain, string, bindings) do
-      {:ok, string} ->
-        string
-      {:default, string} ->
-        string
-      {:error, error} ->
-        raise Gettext.Interpolation.MissingKeysError, error
-    end
+    backend.lgettext(locale(), domain, string, bindings)
+    |> handle_backend_result
   end
 
   @spec gettext(atom, binary, Map.t) :: binary
@@ -118,16 +112,17 @@ defmodule Gettext do
 
   @spec dngettext(atom, binary, binary, binary, non_neg_integer, Map.t) :: binary
   def dngettext(backend, domain, id, plural_id, n, bindings \\ %{}) do
-    case backend.lngettext(locale(), domain, id, plural_id, n, bindings) do
-      {atom, string} when atom in [:ok, :default] ->
-        string
-      {:error, error} ->
-        raise Gettext.Interpolation.MissingKeysError, error
-    end
+    backend.lngettext(locale(), domain, id, plural_id, n, bindings)
+    |> handle_backend_result
   end
 
   @spec ngettext(atom, binary, binary, non_neg_integer, Map.t) :: binary
   def ngettext(backend, id, plural_id, n, bindings \\ %{}) do
     dngettext(backend, "default", id, plural_id, n, bindings)
   end
+
+  defp handle_backend_result({atom, string}) when atom in [:ok, :default],
+    do: string
+  defp handle_backend_result({:error, error}),
+    do: raise(Gettext.Interpolation.MissingKeysError, error)
 end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -41,6 +41,8 @@ defmodule Gettext do
 
   """
 
+  @type locale :: binary
+
   @doc false
   defmacro __using__(opts) do
     quote do
@@ -49,4 +51,13 @@ defmodule Gettext do
       unquote(Gettext.Compiler.signatures)
     end
   end
+
+  @spec locale() :: locale
+  def locale, do: Process.get(__MODULE__, :en)
+
+  @spec locale(locale) :: nil
+  def locale(locale) when is_binary(locale),
+    do: Process.put(__MODULE__, locale)
+  def locale(_locale),
+    do: raise(ArgumentError, "locale/1 only accepts binary locales")
 end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -29,8 +29,7 @@ defmodule Gettext.Compiler do
 
       defmacro dgettext(domain, msgid, bindings) when is_binary(msgid) do
         quote do
-          locale = Gettext.locale
-          unquote(__MODULE__).lgettext(locale, unquote(domain), unquote(msgid), unquote(bindings))
+          unquote(__MODULE__).lgettext(Gettext.locale, unquote(domain), unquote(msgid), unquote(bindings))
         end
       end
 
@@ -49,9 +48,8 @@ defmodule Gettext.Compiler do
       defmacro dngettext(domain, msgid, msgid_plural, n, bindings)
           when is_binary(msgid) and is_binary(msgid_plural) do
         quote do
-          locale = Gettext.locale
           unquote(__MODULE__).lngettext(
-            locale,
+            Gettext.locale,
             unquote(domain),
             unquote(msgid),
             unquote(msgid_plural),

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -17,7 +17,6 @@ defmodule Gettext.Compiler do
 
     quote do
       unquote(macros)
-      unquote(binding_conversion_clauses)
       unquote(compile_po_files(translations_dir))
       unquote(dynamic_clauses)
     end
@@ -85,22 +84,6 @@ defmodule Gettext.Compiler do
     quote do
       def lgettext(locale, domain, msgid, bindings \\ %{})
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings \\ %{})
-    end
-  end
-
-  # Returns the quoted code for the clauses of `lgettext/4` and `lngettext/6`
-  # that convert bindings passed in as keyword lists into maps.
-  defp binding_conversion_clauses do
-    quote do
-      def lgettext(locale, domain, msgid, bindings) when is_list(bindings) do
-        lgettext(locale, domain, msgid, Enum.into(bindings, %{}))
-      end
-
-      def lngettext(locale, domain, msgid, msgid_plural, n, bindings)
-          when is_list(bindings) do
-        bindings = Enum.into(bindings, %{})
-        lngettext(locale, domain, msgid, msgid_plural, n, bindings)
-      end
     end
   end
 

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -33,7 +33,7 @@ defmodule Gettext.Compiler do
         end
 
         quote do
-          unquote(__MODULE__).lgettext(Gettext.locale, unquote(domain), unquote(msgid), unquote(bindings))
+          Gettext.dgettext(unquote(__MODULE__), unquote(domain), unquote(msgid), unquote(bindings))
         end
       end
 
@@ -52,8 +52,8 @@ defmodule Gettext.Compiler do
         end
 
         quote do
-          unquote(__MODULE__).lngettext(
-            Gettext.locale,
+          Gettext.dngettext(
+            unquote(__MODULE__),
             unquote(domain),
             unquote(msgid),
             unquote(msgid_plural),

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -29,7 +29,7 @@ defmodule Gettext.Compiler do
 
       defmacro dgettext(domain, msgid, bindings) when is_binary(msgid) do
         quote do
-          locale = Process.get(Gettext)
+          locale = Gettext.locale
           unquote(__MODULE__).lgettext(locale, unquote(domain), unquote(msgid), unquote(bindings))
         end
       end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -43,6 +43,39 @@ defmodule Gettext.Compiler do
           unquote(__MODULE__).dgettext("default", unquote(msgid), unquote(bindings))
         end
       end
+
+      defmacro dngettext(domain, msgid, msgid_plural, n, bindings \\ Macro.escape(%{}))
+
+      defmacro dngettext(domain, msgid, msgid_plural, n, bindings)
+          when is_binary(msgid) and is_binary(msgid_plural) do
+        quote do
+          locale = Gettext.locale
+          unquote(__MODULE__).lngettext(
+            locale,
+            unquote(domain),
+            unquote(msgid),
+            unquote(msgid_plural),
+            unquote(n),
+            unquote(bindings)
+          )
+        end
+      end
+
+      defmacro dngettext(_domain, _msgid, _msgid_plural, _n, _bindings) do
+        raise ArgumentError, "msgid and msgid_plural must be string literals"
+      end
+
+      defmacro ngettext(msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
+        quote do
+          unquote(__MODULE__).dngettext(
+            "default",
+            unquote(msgid),
+            unquote(msgid_plural),
+            unquote(n),
+            unquote(bindings)
+          )
+        end
+      end
     end
   end
 

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -25,16 +25,16 @@ defmodule Gettext.Compiler do
 
   defp macros do
     quote unquote: false do
-      defmacro dgettext(domain, msgid, bindings \\ Macro.escape(%{}))
+      defmacro dgettext(domain, msgid, bindings \\ Macro.escape(%{})) do
+        msgid = Macro.expand(msgid, __CALLER__)
 
-      defmacro dgettext(domain, msgid, bindings) when is_binary(msgid) do
+        unless is_binary(msgid) do
+          raise ArgumentError, "msgid must be a string literal"
+        end
+
         quote do
           unquote(__MODULE__).lgettext(Gettext.locale, unquote(domain), unquote(msgid), unquote(bindings))
         end
-      end
-
-      defmacro dgettext(_domain, _msgid, _bindings) do
-        raise ArgumentError, "msgid must be a string literal"
       end
 
       defmacro gettext(msgid, bindings \\ Macro.escape(%{})) do
@@ -43,10 +43,14 @@ defmodule Gettext.Compiler do
         end
       end
 
-      defmacro dngettext(domain, msgid, msgid_plural, n, bindings \\ Macro.escape(%{}))
+      defmacro dngettext(domain, msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
+        msgid        = Macro.expand(msgid, __CALLER__)
+        msgid_plural = Macro.expand(msgid_plural, __CALLER__)
 
-      defmacro dngettext(domain, msgid, msgid_plural, n, bindings)
-          when is_binary(msgid) and is_binary(msgid_plural) do
+        unless is_binary(msgid) && is_binary(msgid_plural) do
+          raise ArgumentError, "msgid and msgid_plural must be string literals"
+        end
+
         quote do
           unquote(__MODULE__).lngettext(
             Gettext.locale,
@@ -57,10 +61,6 @@ defmodule Gettext.Compiler do
             unquote(bindings)
           )
         end
-      end
-
-      defmacro dngettext(_domain, _msgid, _msgid_plural, _n, _bindings) do
-        raise ArgumentError, "msgid and msgid_plural must be string literals"
       end
 
       defmacro ngettext(msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -3,6 +3,19 @@ defmodule Gettext.Interpolation do
   Provides facilities for working with interpolations.
   """
 
+  defmodule MissingKeysError do
+    @moduledoc """
+    This error is raised when a string is being interpolated and one or more
+    interpolation keys are missing.
+    """
+
+    defexception [:message]
+
+    def exception(message) do
+      %__MODULE__{message: message}
+    end
+  end
+
   @interpolation_regex ~r/
     (?<left>)  # Start, available through :left
     %{         # Literal '%{'

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -3,19 +3,6 @@ defmodule Gettext.Interpolation do
   Provides facilities for working with interpolations.
   """
 
-  defmodule MissingKeysError do
-    @moduledoc """
-    This error is raised when a string is being interpolated and one or more
-    interpolation keys are missing.
-    """
-
-    defexception [:message]
-
-    def exception(message) do
-      %__MODULE__{message: message}
-    end
-  end
-
   @interpolation_regex ~r/
     (?<left>)  # Start, available through :left
     %{         # Literal '%{'

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule Gettext.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger],
+     env: [default_locale: "en"]]
   end
 
   # Dependencies can be Hex packages:

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/default.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/default.po
@@ -1,2 +1,7 @@
 msgid "Hello world"
 msgstr "Ciao mondo"
+
+msgid "One new email"
+msgid_plural "%{count} new emails"
+msgstr[0] "Una nuova email"
+msgstr[1] "%{count} nuove email"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -156,6 +156,8 @@ defmodule GettextTest do
            == {:error, "missing interpolation keys: name"}
   end
 
+  # Macros.
+
   test "gettext/2: binary msgid at compile-time" do
     Gettext.locale "it"
     assert Translator.gettext("Hello world") == {:ok, "Ciao mondo"}
@@ -179,5 +181,29 @@ defmodule GettextTest do
     assert_raise ArgumentError, "msgid must be a string literal", fn ->
       Code.eval_quoted code
     end
+  end
+
+  # Actual Gettext functions (not the ones generated in the modules that `use
+  # Gettext`).
+
+  test "dgettext/4" do
+    Gettext.locale "it"
+
+    msgid = "Invalid email address"
+    assert Gettext.dgettext(Translator, "errors", msgid)
+           == "Indirizzo email non valido"
+
+    assert Gettext.dgettext(Translator, "foo", "Foo") == "Foo"
+
+    msg = "missing interpolation keys: name"
+    assert_raise Gettext.Interpolation.MissingKeysError, msg, fn ->
+      Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{})
+    end
+  end
+
+  test "gettext/3" do
+    Gettext.locale "it"
+    assert Gettext.gettext(Translator, "Hello world") == "Ciao mondo"
+    assert Gettext.gettext(Translator, "Nonexistent") == "Nonexistent"
   end
 end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -244,4 +244,24 @@ defmodule GettextTest do
     assert Gettext.gettext(Translator, "Hello world") == "Ciao mondo"
     assert Gettext.gettext(Translator, "Nonexistent") == "Nonexistent"
   end
+
+  test "dngettext/6" do
+    Gettext.locale "it"
+    msgid        = "You have one message, %{name}"
+    msgid_plural = "You have %{count} messages, %{name}"
+    assert Gettext.dngettext(Translator, "interpolations", msgid, msgid_plural, 1, %{name: "Meg"})
+           == "Hai un messaggio, Meg"
+    assert Gettext.dngettext(Translator, "interpolations", msgid, msgid_plural, 5, %{name: "Meg"})
+           == "Hai 5 messaggi, Meg"
+  end
+
+  test "ngettext/5" do
+    Gettext.locale "it"
+    msgid        = "One cake, %{name}"
+    msgid_plural = "%{count} cakes, %{name}"
+    assert Gettext.ngettext(Translator, msgid, msgid_plural, 1, %{name: "Meg"})
+           == "One cake, Meg"
+    assert Gettext.ngettext(Translator, msgid, msgid_plural, 5, %{name: "Meg"})
+           == "5 cakes, Meg"
+  end
 end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -149,11 +149,15 @@ defmodule GettextTest do
     Gettext.locale "it"
 
     assert Translator.dgettext("errors", "Invalid email address")
-           == {:ok, "Indirizzo email non valido"}
-    assert Translator.dgettext("interpolations", "Hello %{name}", %{name: "Jim"})
-           == {:ok, "Ciao Jim"}
-    assert Translator.dgettext("interpolations", "Hello %{name}")
-           == {:error, "missing interpolation keys: name"}
+           == "Indirizzo email non valido"
+    keys = %{name: "Jim"}
+    assert Translator.dgettext("interpolations", "Hello %{name}", keys)
+           == "Ciao Jim"
+
+    msg = "missing interpolation keys: name"
+    assert_raise Gettext.Error, msg, fn ->
+      Translator.dgettext("interpolations", "Hello %{name}")
+    end
   end
 
   # Macros.
@@ -162,8 +166,8 @@ defmodule GettextTest do
 
   test "gettext/2: binary-ish msgid at compile-time" do
     Gettext.locale "it"
-    assert Translator.gettext("Hello world") == {:ok, "Ciao mondo"}
-    assert Translator.gettext(@gettext_msgid) == {:ok, "Ciao mondo"}
+    assert Translator.gettext("Hello world") == "Ciao mondo"
+    assert Translator.gettext(@gettext_msgid) == "Ciao mondo"
   end
 
   test "dgettext/3 and gettext/2: non-binary msgid at compile-time" do
@@ -194,14 +198,14 @@ defmodule GettextTest do
       "You have %{count} messages, %{name}",
       1,
       %{name: "James"}
-    ) == {:ok, "Hai un messaggio, James"}
+    ) == "Hai un messaggio, James"
     assert Translator.dngettext(
       "interpolations",
       "You have one message, %{name}",
       "You have %{count} messages, %{name}",
       2,
       %{name: "James"}
-    ) == {:ok, "Hai 2 messaggi, James"}
+    ) == "Hai 2 messaggi, James"
   end
 
   test "dngettext/5: non-literal string arguments" do
@@ -221,14 +225,19 @@ defmodule GettextTest do
   test "ngettext/4" do
     Gettext.locale "it"
     assert Translator.ngettext("One new email", "%{count} new emails", 1)
-           == {:ok, "Una nuova email"}
+           == "Una nuova email"
     assert Translator.ngettext("One new email", "%{count} new emails", 2)
-           == {:ok, "2 nuove email"}
+           == "2 nuove email"
 
     assert Translator.ngettext(@ngettext_msgid, @ngettext_msgid_plural, 1)
-           == {:ok, "Una nuova email"}
+           == "Una nuova email"
     assert Translator.ngettext(@ngettext_msgid, @ngettext_msgid_plural, 2)
-           == {:ok, "2 nuove email"}
+           == "2 nuove email"
+  end
+
+  test "the d?n?gettext macros support a kw list for interpolation" do
+    Gettext.locale "it"
+    assert Translator.gettext("%{msg}", msg: "foo") == "foo"
   end
 
 
@@ -274,5 +283,10 @@ defmodule GettextTest do
            == "One cake, Meg"
     assert Gettext.ngettext(Translator, msgid, msgid_plural, 5, %{name: "Meg"})
            == "5 cakes, Meg"
+  end
+
+  test "the d?n?gettext functions support kw list for interpolations" do
+    Gettext.locale "it"
+    assert Gettext.gettext(Translator, "Hello %{name}", name: "José") == "Hello José"
   end
 end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -77,11 +77,11 @@ defmodule GettextTest do
   end
 
   test "interpolation is supported by lgettext" do
-    assert Translator.lgettext("it", "interpolations", "Hello %{name}", name: "Jane")
+    assert Translator.lgettext("it", "interpolations", "Hello %{name}", %{name: "Jane"})
            == {:ok, "Ciao Jane"}
 
     msgid = "My name is %{name} and I'm %{age}"
-    assert Translator.lgettext("it", "interpolations", msgid, name: "Meg", age: 33)
+    assert Translator.lgettext("it", "interpolations", msgid, %{name: "Meg", age: 33})
            == {:ok, "Mi chiamo Meg e ho 33 anni"}
 
     # A map of bindings is supported as well.
@@ -99,7 +99,7 @@ defmodule GettextTest do
 
     msgid        = "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, name: "Jane")
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{name: "Jane"})
            == {:ok, "Hai un messaggio, Jane"}
     assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 0, %{name: "Jane"})
            == {:ok, "Hai 0 messaggi, Jane"}
@@ -113,7 +113,7 @@ defmodule GettextTest do
 
   test "lgettext/4: interpolation works when a translation is missing" do
     msgid = "Hello %{name}, missing translation!"
-    assert Translator.lgettext("pl", "foo", msgid, name: "Samantha")
+    assert Translator.lgettext("pl", "foo", msgid, %{name: "Samantha"})
            == {:default, "Hello Samantha, missing translation!"}
 
     msgid = "Hello world!"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -183,6 +183,44 @@ defmodule GettextTest do
     end
   end
 
+  test "dngettext/5" do
+    Gettext.locale "it"
+    assert Translator.dngettext(
+      "interpolations",
+      "You have one message, %{name}",
+      "You have %{count} messages, %{name}",
+      1,
+      %{name: "James"}
+    ) == {:ok, "Hai un messaggio, James"}
+    assert Translator.dngettext(
+      "interpolations",
+      "You have one message, %{name}",
+      "You have %{count} messages, %{name}",
+      2,
+      %{name: "James"}
+    ) == {:ok, "Hai 2 messaggi, James"}
+  end
+
+  test "dngettext/5: non-literal string arguments" do
+    code = quote do
+      require Translator
+      msgid_plural = "foos"
+      Translator.dngettext("foo", "foo", msgid_plural, 4)
+    end
+    assert_raise ArgumentError, "msgid and msgid_plural must be string literals", fn ->
+      Code.eval_quoted code
+    end
+  end
+
+  test "ngettext/4" do
+    Gettext.locale "it"
+    assert Translator.ngettext("One new email", "%{count} new emails", 1)
+           == {:ok, "Una nuova email"}
+    assert Translator.ngettext("One new email", "%{count} new emails", 2)
+           == {:ok, "2 nuove email"}
+  end
+
+
   # Actual Gettext functions (not the ones generated in the modules that `use
   # Gettext`).
 

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -234,7 +234,7 @@ defmodule GettextTest do
     assert Gettext.dgettext(Translator, "foo", "Foo") == "Foo"
 
     msg = "missing interpolation keys: name"
-    assert_raise Gettext.Interpolation.MissingKeysError, msg, fn ->
+    assert_raise Gettext.Error, msg, fn ->
       Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{})
     end
   end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -14,6 +14,10 @@ defmodule GettextTest do
   require Translator
   require TranslatorWithCustomPriv
 
+  test "the default locale is \"en\"" do
+    assert Gettext.locale == "en"
+  end
+
   test "locale/0-1: sets and gets the locale" do
     Gettext.locale("pt_BR")
     assert Gettext.locale == "pt_BR"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -158,9 +158,12 @@ defmodule GettextTest do
 
   # Macros.
 
-  test "gettext/2: binary msgid at compile-time" do
+  @gettext_msgid "Hello world"
+
+  test "gettext/2: binary-ish msgid at compile-time" do
     Gettext.locale "it"
     assert Translator.gettext("Hello world") == {:ok, "Ciao mondo"}
+    assert Translator.gettext(@gettext_msgid) == {:ok, "Ciao mondo"}
   end
 
   test "dgettext/3 and gettext/2: non-binary msgid at compile-time" do
@@ -212,11 +215,19 @@ defmodule GettextTest do
     end
   end
 
+  @ngettext_msgid "One new email"
+  @ngettext_msgid_plural "%{count} new emails"
+
   test "ngettext/4" do
     Gettext.locale "it"
     assert Translator.ngettext("One new email", "%{count} new emails", 1)
            == {:ok, "Una nuova email"}
     assert Translator.ngettext("One new email", "%{count} new emails", 2)
+           == {:ok, "2 nuove email"}
+
+    assert Translator.ngettext(@ngettext_msgid, @ngettext_msgid_plural, 1)
+           == {:ok, "Una nuova email"}
+    assert Translator.ngettext(@ngettext_msgid, @ngettext_msgid_plural, 2)
            == {:ok, "2 nuove email"}
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+# Loads the test application located in test/fixtures/test_application.
+[__DIR__, "fixtures", "test_application", "ebin"]
+|> Path.join
+|> Code.prepend_path
+
 ExUnit.start()


### PR DESCRIPTION
I have a working (albeit a bit rough) version of the public API for Gettext, as per #11.
I want to make sure I got everything right:

* `Gettext.d?n?gettext` has to handle responses from the backend like `{:ok, string}`, `{:default, string}` and `{:error, error}`. If I get an `:ok` or a `:default` I return the string, otherwise I raise, right?
* The `d?n?gettext` macros generated in each backend must only handle `{:ok, string}` responses for now, right? I guess `:error`s should be raised and we should warn on `:default` responses, right?

I'm holding off until I'm sure I'm in the right direction; I still don't implement the `Gettext.d?n?gettext` variants which take a locale as an argument, even if that should be super-quick to do.

Comments? :)