### PR TITLE
`%Gettext.PO{}` struct

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -1,6 +1,7 @@
 defmodule Gettext.Compiler do
   @moduledoc false
 
+  alias Gettext.PO
   alias Gettext.PO.Translation
   alias Gettext.PO.PluralTranslation
   alias Gettext.Interpolation
@@ -127,7 +128,7 @@ defmodule Gettext.Compiler do
   # definitions.
   defp compile_po_file(path, acc) do
     {locale, domain} = locale_and_domain_from_path(path)
-    translations     = Gettext.PO.parse_file!(path)
+    %PO{translations: translations} = PO.parse_file!(path)
 
     Enum.reduce translations, acc, fn
       translation, acc -> [compile_translation(locale, domain, translation)|acc]

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -161,4 +161,19 @@ defmodule Gettext.PO.ParserTest do
       {"another/ref/comment.ex", 83},
     ]}]} = parsed
   end
+
+  test "headers are parsed when present" do
+    parsed = Parser.parse([
+      {:msgid, 1}, {:str, 1, ""},
+      {:msgstr, 1},
+        {:str, 1, "Language: en_US\n"},
+        {:str, 1, "Last-Translator: Jane Doe <jane@doe.com>\n"}
+    ])
+
+    assert parsed == {
+      :ok,
+      ["Language: en_US", "Last-Translator: Jane Doe <jane@doe.com>"],
+      []
+    }
+  end
 end

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -11,7 +11,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "ciao"}
     ])
 
-    assert parsed == {:ok, [%Translation{msgid: "hello", msgstr: "ciao"}]}
+    assert parsed == {:ok, [], [%Translation{msgid: "hello", msgstr: "ciao"}]}
   end
 
   test "parse/1 with multiple concatenated strings" do
@@ -20,7 +20,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "ciao"}, {:str, 3, " mondo"}
     ])
 
-    assert parsed == {:ok, [
+    assert parsed == {:ok, [], [
       %Translation{msgid: "hello world", msgstr: "ciao mondo"}
     ]}
   end
@@ -33,7 +33,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 4}, {:str, 4, "parola"},
     ])
 
-    assert parsed == {:ok, [
+    assert parsed == {:ok, [], [
       %Translation{msgid: "hello", msgstr: "ciao"},
       %Translation{msgid: "word", msgstr: "parola"},
     ]}
@@ -45,7 +45,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 2}, {:str, 2, "bårπ"},
     ])
 
-    assert parsed == {:ok, [%Translation{msgid: "føø", msgstr: "bårπ"}]}
+    assert parsed == {:ok, [], [%Translation{msgid: "føø", msgstr: "bårπ"}]}
   end
 
   test "parse/1 with a pluralized string" do
@@ -57,7 +57,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 1}, {:plural_form, 1, 2}, {:str, 1, "barres"},
     ])
 
-    assert parsed == {:ok, [%PluralTranslation{
+    assert parsed == {:ok, [], [%PluralTranslation{
       msgid: "foo",
       msgid_plural: "foos",
       msgstr: %{
@@ -77,7 +77,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 5}, {:str, 5, "bar"},
     ])
 
-    assert parsed == {:ok, [%Translation{
+    assert parsed == {:ok, [], [%Translation{
       msgid: "foo",
       msgstr: "bar",
       comments: [
@@ -98,7 +98,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 3}, {:str, 3, "d"},
     ])
 
-    assert parsed == {:ok, [
+    assert parsed == {:ok, [], [
       %Translation{msgid: "a", msgstr: "b"},
       %Translation{msgid: "c", msgstr: "d", comments: ["# Comment"]},
     ]}
@@ -155,7 +155,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 1}, {:str, 3, "bar"},
     ])
 
-    assert {:ok, [%Translation{references: [
+    assert {:ok, [], [%Translation{references: [
       {"foo.ex", 1},
       {"filename with spaces.ex", 12},
       {"another/ref/comment.ex", 83},

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -67,6 +67,28 @@ defmodule Gettext.POTest do
     end
   end
 
+  test "parse_string(!)/1: headers" do
+    str = ~S"""
+    msgid ""
+    msgstr ""
+      "Project-Id-Version: xxx\n"
+      "Report-Msgid-Bugs-To: \n"
+      "POT-Creation-Date: 2010-07-06 12:31-0500\n"
+
+    msgid "foo"
+    msgstr "bar"
+    """
+
+    assert {:ok, %PO{
+      translations: [%Translation{msgid: "foo", msgstr: "bar"}],
+      headers: [
+        "Project-Id-Version: xxx",
+        "Report-Msgid-Bugs-To: ",
+        "POT-Creation-Date: 2010-07-06 12:31-0500",
+      ]
+    }} = PO.parse_string(str)
+  end
+
   test "parse_file/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -16,10 +16,10 @@ defmodule Gettext.POTest do
       msgstr "indentazione " "e stringhe"
     """
 
-    assert PO.parse_string(str) == {:ok, [
+    assert PO.parse_string(str) == {:ok, %PO{headers: [], translations: [
       %Translation{msgid: "hello there", msgstr: "ciao"},
       %Translation{msgid: "indenting and strings", msgstr: "indentazione e stringhe"},
-    ]}
+    ]}}
   end
 
   test "parse_string/1: invalid strings" do
@@ -45,7 +45,10 @@ defmodule Gettext.POTest do
     msgstr "bar"
     """
 
-    assert PO.parse_string!(str) == [%Translation{msgid: "foo", msgstr: "bar"}]
+    assert PO.parse_string!(str) == %PO{
+      translations: [%Translation{msgid: "foo", msgstr: "bar"}],
+      headers: []
+    }
   end
 
   test "parse_string!/1: invalid strings" do
@@ -67,10 +70,10 @@ defmodule Gettext.POTest do
   test "parse_file/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 
-    assert PO.parse_file(fixture_path) == {:ok, [
+    assert PO.parse_file(fixture_path) == {:ok, %PO{headers: [], translations: [
       %Translation{msgid: "hello", msgstr: "ciao"},
       %Translation{msgid: "how are you, friend?", msgstr: "come stai, amico?"},
-    ]}
+    ]}}
   end
 
   test "parse_file/1: invalid file contents" do
@@ -88,10 +91,10 @@ defmodule Gettext.POTest do
   test "parse_file!/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 
-    assert PO.parse_file!(fixture_path) == [
+    assert PO.parse_file!(fixture_path) == %PO{headers: [], translations: [
       %Translation{msgid: "hello", msgstr: "ciao"},
       %Translation{msgid: "how are you, friend?", msgstr: "come stai, amico?"},
-    ]
+    ]}
   end
 
   test "parse_file!/1: invalid file contents" do


### PR DESCRIPTION
Hey there @josevalim, I implemented the `%Gettext.PO{}` struct we talked about some time ago, can you take a quick look at this to see if you had something like it in mind?

What I tried to do is separating responsibilities as much as possible: I think `Gettext.PO.Parser` shouldn't know about `%Gettext.PO{}`s, so I made `Gettext.PO.Parser.parse/1` return a tuple like `{:ok, headers, translations}` instead of `{:ok, translations}`. An instance of `%Gettext.PO{}` is built up in `Gettext.PO.parse_(string|file)` so that only `PO` knows about `%PO{}`. Wdyt?