### PR TITLE
`:po_source` field for translations

### DIFF
--- a/lib/gettext/po.ex
+++ b/lib/gettext/po.ex
@@ -107,8 +107,13 @@ defmodule Gettext.PO do
   @spec parse_file(Path.t) :: {:ok, t} | parse_error | {:error, atom}
   def parse_file(path) do
     case File.read(path) do
-      {:ok, contents}           -> parse_string(contents)
-      {:error, _reason} = error -> error
+      {:ok, contents} ->
+        case parse_string(contents) do
+          {:ok, po}                        -> {:ok, populate_po_source_field(po, path)}
+          {:error, _line, _reason} = error -> error
+        end
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -136,6 +141,14 @@ defmodule Gettext.PO do
       {:error, line, reason} ->
         raise SyntaxError, file: path, line: line, reason: reason
     end
+  end
+
+  defp populate_po_source_field(%PO{translations: translations} = po, path) do
+    translations = Enum.map translations, fn(%{po_source: {_, line}} = t) ->
+      %{t | po_source: {path, line}}
+    end
+
+    %{po | translations: translations}
   end
 
   @doc """

--- a/lib/gettext/po.ex
+++ b/lib/gettext/po.ex
@@ -31,11 +31,14 @@ defmodule Gettext.PO do
 
   ## Examples
 
-      iex> Gettext.PO.parse_string """
+      iex> {:ok, po} = Gettext.PO.parse_string """
       ...> msgid "foo"
       ...> msgstr "bar"
       ...> """
-      {:ok, %Gettext.PO{translations: [%Gettext.PO.Translation{msgid: ["foo"], msgstr: ["bar"]}], headers: []}}
+      iex> po.translations
+      [%Gettext.PO.Translation{msgid: ["foo"], msgstr: ["bar"], po_source: {nil, 1}}]
+      iex> po.headers
+      []
 
       iex> Gettext.PO.parse_string "foo"
       {:error, 1, "unknown keyword 'foo'"}

--- a/lib/gettext/po/parser.ex
+++ b/lib/gettext/po/parser.ex
@@ -12,14 +12,16 @@ defmodule Gettext.PO.Parser do
   def parse(tokens) do
     case :gettext_po_parser.parse(tokens) do
       {:ok, translations} ->
-        {headers, translations} =
-          translations
-          |> Enum.map(&to_struct/1)
-          |> extract_headers()
-        {:ok, headers, translations}
+        do_parse(translations)
       {:error, _reason} = error ->
         parse_error(error)
     end
+  end
+
+  defp do_parse(translations) do
+    translations = Enum.map(translations, &to_struct/1)
+    {headers, translations} = extract_headers(translations)
+    {:ok, headers, translations}
   end
 
   defp to_struct({:translation, translation}),

--- a/lib/gettext/po/plural_translation.ex
+++ b/lib/gettext/po/plural_translation.ex
@@ -21,6 +21,8 @@ defmodule Gettext.PO.PluralTranslation do
       `["# foo"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
+    * `po_source` - a `{file, line}` tuple which tells the PO file (and line) the
+      translation comes from.
 
   """
 
@@ -30,8 +32,9 @@ defmodule Gettext.PO.PluralTranslation do
     msgstr: %{non_neg_integer => [binary]},
     comments: [binary],
     references: [{binary, pos_integer}],
+    po_source: {Path.t, pos_integer},
   }
 
   defstruct msgid: nil, msgid_plural: nil, msgstr: nil,
-            comments: [], references: []
+            comments: [], references: [], po_source: nil
 end

--- a/lib/gettext/po/translation.ex
+++ b/lib/gettext/po/translation.ex
@@ -20,6 +20,8 @@ defmodule Gettext.PO.Translation do
       `["# foo"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
+    * `po_source` - a `{file, line}` tuple which tells the PO file (and line) the
+      translation comes from.
 
   """
 
@@ -28,7 +30,12 @@ defmodule Gettext.PO.Translation do
     msgstr: [binary],
     comments: [binary],
     references: [{binary, pos_integer}],
+    po_source: {Path.t, pos_integer},
   }
 
-  defstruct msgid: nil, msgstr: nil, comments: [], references: []
+  defstruct msgid: nil,
+            msgstr: nil,
+            comments: [],
+            references: [],
+            po_source: nil
 end

--- a/src/gettext_po_parser.yrl
+++ b/src/gettext_po_parser.yrl
@@ -13,16 +13,18 @@ translations ->
 
 translation ->
   comments msgid strings msgstr strings : {translation, #{
-    comments => '$1',
-    msgid    => '$3',
-    msgstr   => '$5'
+    comments  => '$1',
+    msgid     => '$3',
+    msgstr    => '$5',
+    po_source => {nil, extract_line('$2')}
   }}.
 translation ->
   comments msgid strings msgid_plural strings pluralizations : {plural_translation, #{
     comments     => '$1',
     msgid        => '$3',
     msgid_plural => '$5',
-    msgstr       => plural_forms_map_from_list('$6')
+    msgstr       => plural_forms_map_from_list('$6'),
+    po_source    => {nil, extract_line('$2')}
   }}.
 
 pluralizations ->
@@ -48,6 +50,9 @@ Erlang code.
 
 extract_simple_token({_Token, _Line, Value}) ->
   Value.
+
+extract_line({_Token, Line}) ->
+  Line.
 
 plural_forms_map_from_list(Pluralizations) ->
   Tuples = lists:map(fun extract_plural_form/1, Pluralizations),

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -112,6 +112,15 @@ defmodule Gettext.POTest do
     assert PO.parse_file("nonexistent") == {:error, :enoent}
   end
 
+  test "parse_file/1: populates the :po_source field of translations with the parsed file" do
+    fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
+
+    {:ok, po} = PO.parse_file(fixture_path)
+    Enum.each po.translations, fn %{po_source: {file, _line}} ->
+      assert file == fixture_path
+    end
+  end
+
   test "parse_file!/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 
@@ -139,6 +148,14 @@ defmodule Gettext.POTest do
     msg = "could not parse nonexistent: no such file or directory"
     assert_raise File.Error, msg, fn ->
       PO.parse_file!("nonexistent")
+    end
+  end
+
+  test "parse_file!/1: populates the :po_source field of translations like parse_file/1" do
+    fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
+
+    Enum.each PO.parse_file!(fixture_path).translations, fn %{po_source: {file, _line}} ->
+      assert file == fixture_path
     end
   end
 

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -17,10 +17,10 @@ defmodule Gettext.POTest do
       msgstr "indentazione " "e stringhe"
     """
 
-    assert PO.parse_string(str) == {:ok, %PO{headers: [], translations: [
+    assert {:ok, %PO{headers: [], translations: [
       %Translation{msgid: ["hello there"], msgstr: ["ciao"]},
       %Translation{msgid: ["indenting and ", "strings"], msgstr: ["indentazione ", "e stringhe"]},
-    ]}}
+    ]}} = PO.parse_string(str)
   end
 
   test "parse_string/1: invalid strings" do
@@ -46,10 +46,10 @@ defmodule Gettext.POTest do
     msgstr "bar"
     """
 
-    assert PO.parse_string!(str) == %PO{
+    assert %PO{
       translations: [%Translation{msgid: ["foo"], msgstr: ["bar"]}],
       headers: []
-    }
+    } = PO.parse_string!(str)
   end
 
   test "parse_string!/1: invalid strings" do
@@ -94,10 +94,10 @@ defmodule Gettext.POTest do
   test "parse_file/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 
-    assert PO.parse_file(fixture_path) == {:ok, %PO{headers: [], translations: [
+    assert {:ok, %PO{headers: [], translations: [
       %Translation{msgid: ["hello"], msgstr: ["ciao"]},
       %Translation{msgid: ["how are you,", " friend?"], msgstr: ["come stai,", " amico?"]},
-    ]}}
+    ]}} = PO.parse_file(fixture_path)
   end
 
   test "parse_file/1: invalid file contents" do
@@ -115,10 +115,10 @@ defmodule Gettext.POTest do
   test "parse_file!/1: valid file contents" do
     fixture_path = Path.expand("../fixtures/valid.po", __DIR__)
 
-    assert PO.parse_file!(fixture_path) == %PO{headers: [], translations: [
+    assert %PO{headers: [], translations: [
       %Translation{msgid: ["hello"], msgstr: ["ciao"]},
       %Translation{msgid: ["how are you,", " friend?"], msgstr: ["come stai,", " amico?"]},
-    ]}
+    ]} = PO.parse_file!(fixture_path)
   end
 
   test "parse_file!/1: invalid file contents" do


### PR DESCRIPTION
Opening the PR just to notify you, I'm merging it right away :).

I added the `:po_source` field to both the `Translation` and `PluralTranslation` structs, as discussed with @josevalim on IRC. This field is a `{file, line}` tuple which points to where a translation comes from. For now, the `line` in the tuple will be used by the parser in order to throw meaningful errors when duplicate translations are found; the `file` is still unused, but we may use it later on.

There's actually one thing that bothers me: in order to have a file in the `{file, line}` tuple, we have to loop through all the translations in `Gettext.PO.parse_file/1` because we actually don't have a filename before that step; I don't love this but it's the only *very simple* way I could think of (an alternative would have been to pass the filename down to the parser, but I hate that road :(). All of this, and we don't even **use** the file in `:po_source` :) If any of you has a better idea let me know!