### PR TITLE
Add Gettext.with_locale/2

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -482,6 +482,41 @@ defmodule Gettext do
     dngettext(backend, "default", msgid, msgid_plural, n, bindings)
   end
 
+  @doc """
+  Runs `fun` with the gettext locale set to `locale`.
+
+  This function just sets the Gettext locale to `locale` before running `fun`
+  and sets it back to its previous value afterwards. Note that `locale/1` is
+  used to set the locale, which is thus set only for the current process (keep
+  this in mind if you plan on spawning processes inside `fun`).
+
+  The value returned by this function is the return value of `fun`.
+
+  ## Examples
+
+      Gettext.locale "fr"
+
+      MyApp.Gettext.gettext("Hello world")
+      #=> "Bonjour monde"
+
+      Gettext.with_locale "it", fn ->
+        MyApp.Gettext.gettext("Hello world")
+      end
+      #=> "Ciao mondo"
+
+  """
+  @spec with_locale(locale, (() -> term)) :: term
+  def with_locale(locale, fun) do
+    previous_locale = Gettext.locale
+    Gettext.locale(locale)
+
+    try do
+      fun.()
+    after
+      Gettext.locale(previous_locale)
+    end
+  end
+
   defp handle_backend_result({atom, string}) when atom in [:ok, :default],
     do: string
   defp handle_backend_result({:error, error}),

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -307,4 +307,27 @@ defmodule GettextTest do
     Gettext.locale "it"
     assert Gettext.gettext(Translator, "Hello %{name}", name: "José") == "Hello José"
   end
+
+  test "with_locale/2 runs a function with a given locale and returns the returned value" do
+    Gettext.locale "fr"
+    assert Gettext.gettext(Translator, "Hello world") == "Hello world" # no 'fr' translation
+    res = Gettext.with_locale "it", fn ->
+      assert Gettext.gettext(Translator, "Hello world") == "Ciao mondo"
+      :foo
+    end
+
+    assert res == :foo
+  end
+
+  test "with_locale/2 resets the locale even if the given function raises" do
+    Gettext.locale "fr"
+
+    assert_raise RuntimeError, fn ->
+      Gettext.with_locale "it", fn -> raise "foo" end
+    end
+    assert Gettext.locale == "fr"
+
+    catch_throw(Gettext.with_locale "it", fn -> throw :foo end)
+    assert Gettext.locale == "fr"
+  end
 end


### PR DESCRIPTION
This function runs a given function with the process locale set to the given locale. Useful in many situations, tests included.

Closes #28.