### PR TITLE
Fix a bunch of bugs with Gettext.Extractor

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -24,6 +24,10 @@ defmodule Gettext.Compiler do
       # directory that contains .po/.pot files.
       @external_resource unquote(Path.join(translations_dir, ".compile.gettext"))
 
+      if Gettext.Extractor.extracting? do
+        Gettext.ExtractorAgent.add_backend(__MODULE__)
+      end
+
       unquote(macros)
       unquote(compile_po_files(translations_dir))
       unquote(dynamic_clauses)


### PR DESCRIPTION
Basically, files were merged correctly only when one of the Gettext macros was used; files that weren't "touched" by one of the macros didn't change at all. This commit refactors things around so that we register every backend in `Gettext.__using__` (only during extraction) in order to know every `.pot` file at merging time.

Once we have every existing `.pot` files and a bunch of extracted translations (in the form of `%Gettext.PO{}` structs), the algorithm is trivial:

  - if the extracted struct has a matching existing `.pot file`, merge them
  - if an existing `.pot` file has no matching extracted struct, merge it with an empty `%Gettext.PO{}` struct (which means just purge obsolete translations)
  - add all the remaining extracted structs as new `.pot` files

@josevalim let me know what you think, there's probably a bunch of refactoring to do but the idea should be there.