### PR TITLE
Add support for the --merge opt in gettext.extract

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -72,8 +72,8 @@ defmodule Mix.Tasks.Gettext.Extract do
 
   defp run_merge(changed_pot_files) do
     changed_pot_files
-    |> Enum.group_by(&Path.dirname/1)
-    |> Map.keys
+    |> Enum.map(&Path.dirname/1)
+    |> Enum.uniq
     |> Enum.each(fn priv -> Mix.Task.run("gettext.merge", [priv]) end)
   end
 end


### PR DESCRIPTION
This PR adds support for the `--merge` option in `gettext.extract`. @josevalim documented the option a couple of commits ago.

The implementation turned out to be pretty straightforward, I'm quite happy with the results.

Closes #38.