### PR TITLE
Add the :fuzzy field to translations

### DIFF
--- a/lib/gettext/po/plural_translation.ex
+++ b/lib/gettext/po/plural_translation.ex
@@ -21,6 +21,8 @@ defmodule Gettext.PO.PluralTranslation do
       `["# foo"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
+    * `fuzzy` - a boolean that tells whether this translation was marked as
+      fuzzy.
     * `po_source_line` - the line this translation is on in the PO file where it
       comes from.
 
@@ -32,9 +34,10 @@ defmodule Gettext.PO.PluralTranslation do
     msgstr: %{non_neg_integer => [binary]},
     comments: [binary],
     references: [{binary, pos_integer}],
+    fuzzy: boolean,
     po_source_line: pos_integer,
   }
 
   defstruct msgid: nil, msgid_plural: nil, msgstr: nil,
-            comments: [], references: [], po_source_line: nil
+            comments: [], references: [], fuzzy: false, po_source_line: nil
 end

--- a/lib/gettext/po/translation.ex
+++ b/lib/gettext/po/translation.ex
@@ -20,6 +20,8 @@ defmodule Gettext.PO.Translation do
       `["# foo"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
+    * `fuzzy` - a boolean that tells whether this translation was marked as
+      fuzzy.
     * `po_source_line` - the line this translation is on in the PO file where it
       comes from.
 
@@ -30,6 +32,7 @@ defmodule Gettext.PO.Translation do
     msgstr: [binary],
     comments: [binary],
     references: [{binary, pos_integer}],
+    fuzzy: boolean,
     po_source_line: pos_integer,
   }
 
@@ -37,5 +40,6 @@ defmodule Gettext.PO.Translation do
             msgstr: nil,
             comments: [],
             references: [],
+            fuzzy: false,
             po_source_line: nil
 end

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -162,6 +162,19 @@ defmodule Gettext.PO.ParserTest do
     ]}]} = parsed
   end
 
+  test "if there's a 'fuzzy' flag, it sets the :fuzzy field of a translation to true" do
+    parsed = Parser.parse([
+      {:comment, 1, "#, flag fuzzy other-flag"},
+      {:msgid, 2}, {:str, 2, "foo"},
+      {:msgstr, 3}, {:str, 3, "bar"},
+    ])
+
+    assert {:ok, [], [%Translation{
+      fuzzy: true,
+      comments: ["#, flag fuzzy other-flag"],
+    }]} = parsed
+  end
+
   test "the line of a translation is the line of its msgid" do
     parsed = Parser.parse([
       {:msgid, 10}, {:str, 10, "foo"},

--- a/test/gettext/po/tokenizer_test.exs
+++ b/test/gettext/po/tokenizer_test.exs
@@ -104,6 +104,11 @@ defmodule Gettext.PO.TokenizerTest do
     assert tokenize(str) == {:ok, [
       {:comment, 1, "#: Single-line reference comment"}
     ]}
+
+    str = "#, Flags comment"
+    assert tokenize(str) == {:ok, [
+      {:comment, 1, "#, Flags comment"}
+    ]}
   end
 
   test "multi-line comments are supported" do


### PR DESCRIPTION
The `:fuzzy` field of a translation is populated (when a translation is parsed) if there is a "fuzzy" flag in one of the flag comments (the ones starting with `#,`) for said translation. The `#,` comments are kept in the `:comments` field of a translation, similarly to how `:references` works.

@josevalim just wanted to check what you think about adding `:fuzzy`. The alternative would be to add a `:flags` field with all the flags (and maybe provide something like `Gettext.PO.Translations.fuzzy?/1`).