### PR TITLE
Move :fuzzy_threshold out of :gettext's env

### DIFF
--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -83,6 +83,8 @@ defmodule Mix.Tasks.Gettext.Merge do
 
   """
 
+  @default_fuzzy_threshold 0.8
+
   alias Gettext.Merger
 
   def run(args) do
@@ -217,10 +219,12 @@ defmodule Mix.Tasks.Gettext.Merge do
   end
 
   defp validate_merging_opts!(opts) do
-    default = [fuzzy: true, fuzzy_threshold: Application.get_env(:gettext, :fuzzy_threshold)]
-    opts = Keyword.merge(default, Keyword.take(opts, [:fuzzy, :fuzzy_threshold]))
+    default_threshold = Application.get_env(:gettext, :fuzzy_threshold, @default_fuzzy_threshold)
+    defaults = [fuzzy: true, fuzzy_threshold: default_threshold]
+    opts = Keyword.merge(defaults, Keyword.take(opts, [:fuzzy, :fuzzy_threshold]))
 
-    unless opts[:fuzzy_threshold] in 0..1 do
+    threshold = opts[:fuzzy_threshold]
+    unless threshold >= 0.0 and threshold <= 1.0 do
       Mix.raise "The :fuzzy_threshold option must be a float in 0..1"
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Gettext.Mixfile do
 
   def application do
     [applications: [:logger],
-     env: [default_locale: "en", fuzzy_threshold: 0.8]]
+     env: [default_locale: "en"]]
   end
 
   def hex_package do


### PR DESCRIPTION
@josevalim we store the default for `:fuzzy_threshold` in `:gettext`'s `:env` but we don't load gettext here in a mix task I guess? We don't have the env anyway. FWIW, It also works if I leave the option in the `:env` and call `Application.load(:gettext)` before fetching it, not sure which one is better here (this looks simpler though).