### PR TITLE
References

### DIFF
--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -138,8 +138,7 @@ defmodule Gettext.ExtractorTest do
     expected = [
       {"priv/gettext/default.pot",
         """
-        #: foo.ex:14
-        #: foo.ex:16
+        #: foo.ex:14 foo.ex:16
         msgid "foo"
         msgstr ""
         """},

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -243,4 +243,18 @@ defmodule Gettext.PO.ParserTest do
   test "an empty list of tokens is parsed as an empty list of translations" do
     assert Parser.parse([]) == {:ok, [], []}
   end
+
+  test "multiple references on the same line are parsed correctly" do
+    parsed = Parser.parse([
+      {:comment, 1, "#: foo.ex:1 bar.ex:2 with spaces.ex:3"},
+      {:comment, 2, "#: baz.ex:3"},
+      {:msgid, 3}, {:str, 3, "foo"}, {:msgstr, 3}, {:str, 3, "bar"},
+    ])
+
+    assert {:ok, [], [%Translation{} = t]} = parsed
+    assert t.references == [{"foo.ex", 1},
+                            {"bar.ex", 2},
+                            {"with spaces.ex", 3},
+                            {"baz.ex", 3}]
+  end
 end

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -230,21 +230,39 @@ defmodule Gettext.POTest do
         msgid: ["foo"],
         msgid_plural: ["foos"],
         msgstr: %{0 => [""], 1 => [""]},
-        references: [{"lib/with spaces.ex", 1}],
+        references: [{"lib/with spaces.ex", 1}, {"lib/with other spaces.ex", 2}],
       }
     ]}
 
     assert IO.iodata_to_binary(PO.dump(po)) == ~S"""
-    #: foo.ex:1
-    #: lib/bar.ex:2
+    #: foo.ex:1 lib/bar.ex:2
     msgid "foo"
     msgstr "bar"
 
-    #: lib/with spaces.ex:1
+    #: lib/with spaces.ex:1 lib/with other spaces.ex:2
     msgid "foo"
     msgid_plural "foos"
     msgstr[0] ""
     msgstr[1] ""
+    """
+  end
+
+  test "dump/1: references are wrapped" do
+    po = %PO{translations: [
+      %Translation{
+        msgid: ["foo"],
+        msgstr: ["bar"],
+        references: [{String.duplicate("a", 50) <> ".ex", 1},
+                     {String.duplicate("b", 50) <> ".ex", 2}],
+      },
+    ]}
+
+
+    assert IO.iodata_to_binary(PO.dump(po)) == ~S"""
+    #: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ex:1
+    #: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ex:2
+    msgid "foo"
+    msgstr "bar"
     """
   end
 


### PR DESCRIPTION
@josevalim I'm not proud of the implementation, but the feature works: parsing multiple references on the same line and dumping PO with all the references joined in one line and then wrapped.

On IRC the problem of spaces in file names arrived. I looked at `xgettext` and with this:

```
xgettext "foo bar.c" foo.c
```

you get

```po
# foo bar.c:1 foo.c:1
msgid "foo"
msgstr "bar"
```

So I pretty much decided to use line numbers to separate filenames. So after a line number, everything up to the next line number is the file name. Let me know what you think!

This would close #46.

/cc @tmjoen