### PR TITLE
chore(travis.yml): use Elixir 1.1.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,7 @@ language:
   elixir
 otp_release:
   - 17.4
-
-# TODO: Temporary workaround until Elixir v1.1 is out
-before_install:
-  - wget https://github.com/elixir-lang/elixir/releases/download/v1.1.0-beta/Precompiled.zip
-  - unzip -d elixir Precompiled.zip
-before_script:
-  - export PATH=`pwd`/elixir/bin:$PATH
-
+elixir: 1.1.1
 sudo:
   false
 notifications:


### PR DESCRIPTION
Since Elixir 1.1.1 is out, there is no need to fetch the beta version