### PR TITLE
Fallback to default clauses when msgstrs are empty

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -288,6 +288,13 @@ defmodule Gettext do
       MyApp.Gettext.ngettext "One error", "%{count} errors", 3
       #=> "3 errors"
 
+  ### Empty translations
+
+  When a `msgstr` is empty (`""`), the translation is considered missing and the
+  behaviour described above for missing translation is applied. A plural
+  translation is considered to have an empty `msgstr` if at least one
+  translation in the `msgstr` is empty.
+
   ## Compile-time features
 
   As mentioned above, using the gettext macros (as opposed to functions) allows

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/default.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/default.po
@@ -15,3 +15,11 @@ msgid "A" " friend"
 msgid_plural "%{count}" " friends"
 msgstr[0] "Un" " amico"
 msgstr[1] "%{count}" " amici"
+
+msgid "Empty msgstr!"
+msgstr "" ""
+
+msgid "Not even one msgstr"
+msgid_plural "Not even %{count} msgstrs"
+msgstr[0] ""
+msgstr[1] "<not empty>"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -62,6 +62,11 @@ defmodule GettextTest do
            == {:default, "Hello world"}
   end
 
+  test "translations with empty msgstrs fallback to {:default, _}" do
+    assert Translator.lgettext("it", "default", "Empty msgstr!")
+           == {:default, "Empty msgstr!"}
+  end
+
   test "a custom 'priv' directory can be used to store translations" do
     assert TranslatorWithCustomPriv.lgettext("it", "default", "Hello world")
            == {:ok, "Ciao mondo"}
@@ -85,6 +90,16 @@ defmodule GettextTest do
            == {:default, "foo"}
     assert Translator.lngettext("it", "not a domain", "foo", "foos", 10)
            == {:default, "foos"}
+  end
+
+  test "plural translations with empty msgstrs fallback to {:default, _}" do
+    msgid        = "Not even one msgstr"
+    msgid_plural = "Not even %{count} msgstrs"
+
+    assert Translator.lngettext("it", "default", msgid, msgid_plural, 1)
+           == {:default, "Not even one msgstr"}
+    assert Translator.lngettext("it", "default", msgid, msgid_plural, 2)
+           == {:default, "Not even 2 msgstrs"}
   end
 
   test "interpolation is supported by lgettext" do


### PR DESCRIPTION
Should close #55.

Before this PR, empty msgstrs were treated like any other msgstr. This resulted in a nasty behaviour when generating new PO files (from POT files) with e.g. `mix gettext.merge`, because empty
msgstrs were being returned.

This PR changes the behaviour of the `Gettext.Compiler`, which now doesn't generate a function clause for translations with an empty msgstr at all. This means such translations will fallback to the dynamic clauses of `lgettext` and `lngettext`, which just return the msgid (after interpolation) in a `{:default, _}` tuple. Plural translations are treated this way if they have one or more empty msgstrs.

/cc @chrismccord and @endersstocker