### PR TITLE
Warn when PO files are not in "canonical" path

### DIFF
--- a/test/fixtures/test_application/po_files_in_weird_places/foo.po
+++ b/test/fixtures/test_application/po_files_in_weird_places/foo.po
@@ -1,0 +1,2 @@
+msgid "foo"
+msgstr "bar"

--- a/test/fixtures/test_application/po_files_in_weird_places/subdir/bar.po
+++ b/test/fixtures/test_application/po_files_in_weird_places/subdir/bar.po
@@ -1,0 +1,2 @@
+msgid "bar"
+msgstr "baz"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -9,6 +9,8 @@ end
 defmodule GettextTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
   require Translator
@@ -350,5 +352,18 @@ defmodule GettextTest do
   test "known_locales/1: returns all the locales for which a backend has PO files" do
     assert Gettext.known_locales(Translator) == ["it"]
     assert Gettext.known_locales(TranslatorWithCustomPriv) == ["it"]
+  end
+
+  test "" do
+    code = quote do
+      defmodule POsInWeirdPlaces do
+        use Gettext, otp_app: :test_application, priv: "po_files_in_weird_places"
+      end
+    end
+
+    output = capture_io(:stderr, fn -> Code.eval_quoted(code) end)
+    assert output =~ ~s[PO file ignored because not in "canonical" path (my_locale/LC_MESSAGES/my_domain.po)]
+    assert output =~ "foo.po"
+    assert output =~ "subdir/bar.po"
   end
 end


### PR DESCRIPTION
Possible solution for #74: when compiling a `Gettext` backend and going over the PO files, we warn for all the files that are not in their "canonical" path (which is `my_locale/LC_MESSAGES/my_domain.po`).

I'm not fond of this solution as it introduces something very non-functional (emitting warnings) in an otherwise pretty functional module. Not many other solutions I can think of though. Wdyt?