### PR TITLE
Better comment handling

### DIFF
--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -176,10 +176,11 @@ defmodule Gettext.Extractor do
   defp tag_files({path, new_po}),
     do: {path, {:new, new_po}}
 
-  # This function dumps merged files and unmerged files without any changes, and
-  # dumps new POT files adding an informative comment to them.
+  # This function "dumps" merged files and unmerged files without any changes,
+  # and dumps new POT files adding an informative comment to them. This doesn't
+  # write anything to disk, it just returns `{path, contents}` tuples.
   defp dump_tagged_file({path, {:new, new_po}}),
-    do: {path, [new_pot_comment(), PO.dump(new_po)]}
+    do: {path, [new_pot_comment(), (new_po |> add_headers_to_new_po() |> PO.dump())]}
   defp dump_tagged_file({path, {tag, po}}) when tag in [:unmerged, :merged],
     do: {path, PO.dump(po)}
 
@@ -195,6 +196,10 @@ defmodule Gettext.Extractor do
     ## gettext.extract` to bring this file up to date. Leave `msgstr`s empty as
     ## changing them here as no effect; edit them in PO (`.po`) files instead.
     """
+  end
+
+  defp add_headers_to_new_po(%PO{headers: []} = po) do
+    %{po | headers: ["", "Language: INSERT LANGUAGE HERE\n"]}
   end
 
   # Merges a %PO{} struct representing an existing POT file with an

--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -144,12 +144,12 @@ defmodule Gettext.Extractor do
 
   # Returns :unchanged if merging `existing_path` with `new` changes nothing,
   # otherwise a %Gettext.PO{} struct with the changed contents.
-  defp merge_or_unchanged(existing_path, new) do
+  defp merge_or_unchanged(existing_path, new_struct) do
     existing_contents = File.read!(existing_path)
     merged =
       existing_contents
       |> PO.parse_string!()
-      |> merge_template(new)
+      |> merge_template(new_struct)
 
     if IO.iodata_to_binary(PO.dump(merged)) == existing_contents do
       :unchanged

--- a/src/gettext_po_parser.yrl
+++ b/src/gettext_po_parser.yrl
@@ -6,25 +6,29 @@ Rootsymbol grammar.
 grammar ->
   translations : '$1'.
 
+% A series of translations. It can be just comments (which are discarded and can
+% be empty anyways) or comments followed by a translation followed by other
+% translations; in the latter case, comments are attached to the translation
+% that follows them.
 translations ->
-  '$empty' : [].
+  comments : [].
 translations ->
-  translation translations : ['$1'|'$2'].
+  comments translation translations : [add_comments_to_translation('$2', '$1')|'$3'].
 
 translation ->
-  comments msgid strings msgstr strings : {translation, #{
-    comments       => '$1',
-    msgid          => '$3',
-    msgstr         => '$5',
-    po_source_line => extract_line('$2')
+  msgid strings msgstr strings : {translation, #{
+    comments       => [],
+    msgid          => '$2',
+    msgstr         => '$4',
+    po_source_line => extract_line('$1')
   }}.
 translation ->
-  comments msgid strings msgid_plural strings pluralizations : {plural_translation, #{
-    comments       => '$1',
-    msgid          => '$3',
-    msgid_plural   => '$5',
-    msgstr         => plural_forms_map_from_list('$6'),
-    po_source_line => extract_line('$2')
+  msgid strings msgid_plural strings pluralizations : {plural_translation, #{
+    comments       => [],
+    msgid          => '$2',
+    msgid_plural   => '$4',
+    msgstr         => plural_forms_map_from_list('$5'),
+    po_source_line => extract_line('$1')
   }}.
 
 pluralizations ->
@@ -60,3 +64,6 @@ plural_forms_map_from_list(Pluralizations) ->
 
 extract_plural_form({{plural_form, _Line, PluralForm}, String}) ->
   {PluralForm, String}.
+
+add_comments_to_translation({TranslationType, Translation}, Comments) ->
+  {TranslationType, maps:put(comments, Comments, Translation)}.

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -173,6 +173,7 @@ defmodule Gettext.ExtractorTest do
     assert Enum.all?(dumped, fn {_, contents} ->
       contents =~ "## This file is a PO Template file."
     end)
+
     Extractor.teardown
     refute Extractor.extracting?
   end

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -139,14 +139,22 @@ defmodule Gettext.ExtractorTest do
 
     expected = [
       {"priv/gettext/default.pot",
-        """
+        ~S"""
+        msgid ""
+        msgstr ""
+        "Language: INSERT LANGUAGE HERE\n"
+
         #: foo.ex:14 foo.ex:16
         msgid "foo"
         msgstr ""
         """},
 
       {"priv/gettext/errors.pot",
-          """
+          ~S"""
+          msgid ""
+          msgstr ""
+          "Language: INSERT LANGUAGE HERE\n"
+
           #: foo.ex:15
           msgid "one error"
           msgid_plural "%{count} errors"
@@ -155,7 +163,11 @@ defmodule Gettext.ExtractorTest do
           """},
 
       {"translations/greetings.pot",
-          """
+          ~S"""
+          msgid ""
+          msgstr ""
+          "Language: INSERT LANGUAGE HERE\n"
+
           #: foo.ex:17
           msgid "hi"
           msgstr ""

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -143,6 +143,15 @@ defmodule Gettext.PO.ParserTest do
     assert {:error, 3, _} = parsed
   end
 
+  test "files with just comments are ok (the comments are discarded)" do
+    parsed = Parser.parse([
+      {:comment, 1, "# A comment"},
+      {:comment, 2, "# Another comment"},
+    ])
+
+    assert {:ok, [], [], []} = parsed
+  end
+
   test "reference are extracted into the :reference field of a translation" do
     parsed = Parser.parse([
       {:comment, 1, "#: foo.ex:1 "},

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -418,6 +418,22 @@ defmodule Gettext.POTest do
     """
   end
 
+  test "parsing and re-dumping: dangling comments are ignored and not dumped back" do
+    str = """
+    # comment
+    msgid "foo"
+    msgstr "bar"
+
+    # dangling comment
+    """
+
+    assert (str |> PO.parse_string!() |> PO.dump() |> IO.iodata_to_binary()) == """
+    # comment
+    msgid "foo"
+    msgstr "bar"
+    """
+  end
+
   # Individual testing of the `dump(parse(po)) == po` process for different PO
   # editors.
   for file <- Path.wildcard("test/fixtures/po_editors/*.po") do


### PR DESCRIPTION
We're now:

* adding headers to new POT files (we already added them to new PO files), so that informative comments are kept as the result of being attached to the headers
* handling "dangling" comments, i.e., comments that are not followed by translations (we're simply throwing them away)