### PR TITLE
Better plural forms

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -346,6 +346,8 @@ defmodule Gettext do
       specified by the `:otp_app` option. It is recommended to always have
       this directory inside `"priv"`, otherwise some features like the
       "mix compile.gettext" won't work as expected.
+    * `:plural_forms` - a module which will act as a "pluralizer". For more
+      information, look at the documentation for `Gettext.Plural`.
 
   ## Configuration
 
@@ -357,8 +359,6 @@ defmodule Gettext do
 
   The following is a list of the configuration options that `:gettext` supports:
 
-    * `:plural_forms` - a module which will act as a "pluralizer" module. For
-      more information, look at the documentation for `Gettext.Plural`.
     * `:fuzzy_threshold` - the default threshold for the Jaro distance measuring
       the similarity of translations. Look at the documentation for the `mix
       gettext.merge` task (`Mix.Tasks.Gettext.Merge`) for more information on

--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -20,22 +20,23 @@ defmodule Gettext.Plural do
   are languages which have more than two.
 
   In GNU Gettext (and in Gettext for Elixir), plural forms are represented by
-  increasing 0-indexed integers. In English, `0` means singular and `1` means
-  plural.
+  increasing 0-indexed integers. For example, in English `0` means singular and
+  `1` means plural.
 
-  The goal of this module is to, given a locale, determine:
+  The goal of this module is to determine, given a locale:
 
     * how many plural forms exist in that locale (`nplurals/1`);
     * to what plural form a given number of elements belongs to in that locale
-    (`plural/2`).
+      (`plural/2`).
 
   ## Default implementation
 
   `Gettext.Plural` provides a default implementation of a plural module. Most
-  languages used on Earth should be covered by this default implementation. If a
-  language isn't in this implementation, a different plural module can be
-  provided when `Gettext` is used. For example, pluralization rules for the
-  Elvish language could be added as follows:
+  languages used on Earth should be covered by this default implementation. If
+  custom pluralization rules are needed (for example, to add additional
+  languages) a different plural module can be specified when creating a Gettext
+  backend. For example, pluralization rules for the Elvish language could be
+  added as follows:
 
       defmodule MyApp.Plural do
         @behaviour Gettext.Plural
@@ -45,6 +46,10 @@ defmodule Gettext.Plural do
         def plural("elv", 0), do: 0
         def plural("elv", 1), do: 1
         def plural("elv", _), do: 2
+
+        # Fallback to Gettext.Plural
+        def nplurals(locale), do: Gettext.Plural.nplurals(locale)
+        def plural(locale, n), do: Gettext.Plural.plural(locale, n)
       end
 
       defmodule MyApp.Gettext do

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -6,6 +6,18 @@ defmodule GettextTest.TranslatorWithCustomPriv do
   use Gettext, otp_app: :test_application, priv: "translations"
 end
 
+defmodule GettextTest.TranslatorWithCustomPluralForms do
+  defmodule Plural do
+    @behaviour Gettext.Plural
+    def nplurals("elv"), do: 2
+    # Opposite of Italian (where 1 is singular, everything else is plural)
+    def plural("it", 1), do: 1
+    def plural("it", _), do: 0
+  end
+
+  use Gettext, otp_app: :test_application, plural_forms: Plural
+end
+
 defmodule GettextTest do
   use ExUnit.Case
 
@@ -13,6 +25,7 @@ defmodule GettextTest do
 
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
+  alias GettextTest.TranslatorWithCustomPluralForms
   require Translator
   require TranslatorWithCustomPriv
 
@@ -76,6 +89,14 @@ defmodule GettextTest do
 
     assert TranslatorWithCustomPriv.lgettext("it", "errors", "Invalid email address")
            == {:ok, "Indirizzo email non valido"}
+  end
+
+  test "using a custom Gettext.Plural module" do
+    alias TranslatorWithCustomPluralForms, as: T
+    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 1) ==
+           {:ok, "1 nuove email"}
+    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 2) ==
+           {:ok, "Una nuova email"}
   end
 
   test "translations can be pluralized" do


### PR DESCRIPTION
We were reading the `:plural_forms` option (that specifies which pluralizer module to use) from the configuration of the `:gettext` application, but we want to read that from the configuration of each backend (the one passed to `use Gettext`).

I fixed that and also polished the modules for `Gettext.Plural`.