### PR TITLE
Add the Gettext.Backend behaviour

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -115,7 +115,9 @@ defmodule Gettext do
 
   ### Using macros
 
-  When a module calls `use Gettext`, the following macros are automatically
+  Each module that calls `use Gettext` is usually referred to as a "Gettext
+  backend", as it implements the `Gettext.Backend` behaviour. When a module
+  calls `use Gettext`, the following macros are automatically
   defined inside it:
 
     * `gettext/2`

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -1,0 +1,83 @@
+defmodule Gettext.Backend do
+  @moduledoc """
+  Behaviour that defines the macros that a Gettext backend has to implement.
+
+  These macros are documented in great detail in the documentation for the
+  `Gettext` module.
+  """
+
+  @doc """
+  Translates the given `msgid` in the given `domain`.
+
+  `bindings` is a map of bindings to support interpolation.
+
+  See also `Gettext.dgettext/4`.
+  """
+  @macrocallback dgettext(domain :: Macro.t, msgid :: String.t, bindings :: Macro.t) ::
+    Macro.t
+
+  @doc """
+  Same as `dgettext(domain, msgid, %{})`.
+
+  See also `Gettext.dgettext/4`.
+  """
+  @macrocallback dgettext(domain :: Macro.t, msgid :: String.t) :: Macro.t
+
+  @doc """
+  Same as `dgettext("default", msgid, %{})`.
+
+  See also `Gettext.gettext/3`.
+  """
+  @macrocallback gettext(msgid :: String.t, bindings :: Macro.t) :: Macro.t
+
+  @doc """
+  Same as `gettext(msgid, %{})`.
+
+  See also `Gettext.gettext/3`.
+  """
+  @macrocallback gettext(msgid :: String.t) :: Macro.t
+
+  @doc """
+  Translates the given plural translation (`msgid` + `msgid_plural`) in the
+  given `domain`.
+
+  `n` is an integer used to determine how to pluralize the
+  translation. `bindings` is a map of bindings to support interpolation.
+
+  See also `Gettext.dngettext/6`.
+  """
+  @macrocallback dngettext(domain :: Macro.t,
+                           msgid :: String.t,
+                           msgid_plural :: String.t,
+                           n :: Macro.t,
+                           bindings :: Macro.t) :: Macro.t
+
+  @doc """
+  Same as `dngettext(domain, msgid, msgid_plural, n, %{})`.
+
+  See also `Gettext.dngettext/6`.
+  """
+  @macrocallback dngettext(domain :: Macro.t,
+                           msgid :: String.t,
+                           msgid_plural :: String.t,
+                           n :: Macro.t) :: Macro.t
+
+  @doc """
+  Same as `dngettext("default", msgid, msgid_plural, n, bindings)`.
+
+  See also `Gettext.ngettext/5`.
+  """
+  @macrocallback ngettext(msgid :: String.t,
+                          msgid_plural :: String.t,
+                          n :: Macro.t,
+                          bindings :: Macro.t) :: Macro.t
+
+  @doc """
+  Same as `ngettext(msgid, msgid_plural, n, %{})`.
+
+  See also `Gettext.ngettext/5`.
+  """
+  @macrocallback ngettext(msgid :: String.t,
+                          msgid_plural :: String.t,
+                          n :: Macro.t) :: Macro.t
+end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -20,6 +20,8 @@ defmodule Gettext.Compiler do
     plural_forms     = Keyword.get(opts, :plural_forms, Gettext.Plural)
 
     quote do
+      @behaviour Gettext.Backend
+
       @doc false
       def __gettext__(:priv),          do: unquote(priv)
       def __gettext__(:otp_app),       do: unquote(otp_app)


### PR DESCRIPTION
This behaviour is implemented by all modules that call `use Gettext`. It's mostly useful for documentation. I haven't included the `lgettext/4` and `lngettext/6` callbacks in the behaviour as we keep those function "hidden" (not documented anywhere currently); however, we call those from the `Gettext.*gettext` functions so it may be worth to add them to the behaviour, so that if people want to implement weird Gettext backends they have *all* the correct callbacks.

Wdyt @lexmag and @josevalim? 