### PR TITLE
Don't print tokens as Erlang terms in syntax error

### DIFF
--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -118,7 +118,7 @@ defmodule Gettext.PO.ParserTest do
       {:msgstr, 1}, {:str, 1, "bar"},
     ])
 
-    assert parsed == {:error, 1, "syntax error before: <<\"bar\">>"}
+    assert parsed == {:error, 1, "syntax error before: \"bar\""}
   end
 
   test "'msgid_plural' must come after 'msgid'" do
@@ -283,5 +283,15 @@ defmodule Gettext.PO.ParserTest do
       ["Language: en_US\n"],
       []
     } = parsed
+  end
+
+  test "tokens are printed as Elixir terms, not Erlang terms" do
+    parsed = Parser.parse([
+      {:msgid, 1}, {:str, 1, ""},
+      {:comment, 1, "# comment"},
+    ])
+
+    assert {:error, _line, msg} = parsed
+    assert msg == "syntax error before: \"# comment\""
   end
 end


### PR DESCRIPTION
yecc prints tokens as Erlang terms (e.g., binaries are `<<"like this">>`) instead of Elixir terms. This commit introduces a pretty ugly hack that parses and rewrites yecc error reasons to print some terms as Elixir terms (like binaries) instead of Erlang terms.

This is ugly, but it's necessary given the lack of extensibility in yecc; in fact, Elixir itself does this as can be seen here: https://github.com/elixir-lang/elixir/blob/b806511b887776c1f9ab349a377350b8c9c069f1/lib/elixir/src/elixir_errors.erl#L51-L103.

This should contribute to solving the issues described in #89.