### PR TITLE
Allow duplicate interpolation keys

### DIFF
--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -70,13 +70,16 @@ defmodule Gettext.Interpolation do
       iex> Gettext.Interpolation.keys(["Hello ", :name, "!"])
       [:name]
 
+      iex> Gettext.Interpolation.keys(["Hello ", :name, "! Goodbye", :name])
+      [:name]
+
   """
   @spec keys(binary | [atom]) :: [atom]
 
   def keys(str) when is_binary(str),
-    do: str |> to_interpolatable |> Enum.filter(&is_atom/1)
+    do: str |> to_interpolatable |> keys
   def keys(segments) when is_list(segments),
-    do: Enum.filter(segments, &is_atom/1)
+    do: Enum.filter(segments, &is_atom/1) |> Enum.uniq
 
   @doc """
   Dynimically interpolates `str` with the given `bindings`.

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -42,6 +42,11 @@ defmodule Gettext.InterpolationTest do
            == {:ok, "Hi Sandra"}
   end
 
+  test "interpolate/2: repeated bindings" do
+    assert Interpolation.interpolate("Hello %{name}. Goodbye %{name}", %{name: "Alex"})
+           == {:ok, "Hello Alex. Goodbye Alex"}
+  end
+
   test "keys/1" do
     assert Interpolation.keys("Hello %{name}")
            == [:name]
@@ -49,5 +54,7 @@ defmodule Gettext.InterpolationTest do
            == [:time, :state]
     assert Interpolation.keys("Hi there %{your name}")
            == [:"your name"]
+    assert Interpolation.keys("Hello %{name} in %{state} goodbye %{name}")
+           == [:name, :state]
   end
 end


### PR DESCRIPTION
This fixes a bug where it is not possible to specify the same interpolation key twice in a string
e.g. `"Hello %{name}. Goodbye %{name}"`
