### PR TITLE
Add a :compiler_po_wildcard option to the Gettext configruation

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -375,6 +375,12 @@ defmodule Gettext do
       have a matching reference. You can use this pattern to prevent Gettext from
       removing translations that you have extracted using another tool.
 
+    * `:compiler_po_wildcard` - a binary that specifies the wildcard that the
+      `:gettext` compiler will use to find changed PO files in order to recompile
+      their respective Gettext backends. This wildcard has to be relative to the
+      `"priv"` directory of your application. Defaults to
+      `"gettext/*/LC_MESSAGES/*.po"`.
+
   ### Backend configuration
 
   A Gettext backend such as `MyApp.Gettext` can be configured under the

--- a/lib/mix/tasks/compile.gettext.ex
+++ b/lib/mix/tasks/compile.gettext.ex
@@ -15,13 +15,18 @@ defmodule Mix.Tasks.Compile.Gettext do
   # that each backend specifies the corresponding manifest file as an
   # @external_resource.
 
+  @default_wildcard "gettext/*/LC_MESSAGES/*.po"
+
   def run(_, priv_dir \\ "priv") do
     _ = Mix.Project.get!
     app_dir = Mix.Project.app_path()
+    gettext_config = Mix.Project.config()[:gettext] || []
+
+    wildcard = gettext_config[:compiler_po_wildcard] || @default_wildcard
 
     changed =
       priv_dir
-      |> Path.join("**/*.po")
+      |> Path.join(wildcard)
       |> Path.wildcard()
       |> Enum.group_by(&priv_prefix(&1, app_dir))
       |> Map.delete(:not_in_canonical_dir)

--- a/test/mix/tasks/compile.gettext_test.exs
+++ b/test/mix/tasks/compile.gettext_test.exs
@@ -2,11 +2,18 @@ defmodule Mix.Tasks.Compile.GettextTest do
   use ExUnit.Case, async: true
 
   @po_path "../../../tmp/gettext" |> Path.expand(__DIR__) |> Path.relative_to_cwd
-  @manifest_path Application.app_dir(:gettext)
+
+  defmodule MyProject do
+    def project do
+      [app: :my_project,
+       gettext: [compiler_po_wildcard: "**/*.po"]]
+    end
+  end
 
   setup do
+    Mix.Project.push(MyProject)
     File.rm_rf!(@po_path)
-    File.rm_rf!(Path.join(@manifest_path, ".compile_tmp_gettext_foo"))
+    File.rm_rf!(Path.join(Mix.Project.app_path(), ".compile_tmp_gettext_foo"))
     :ok
   end
 
@@ -57,7 +64,7 @@ defmodule Mix.Tasks.Compile.GettextTest do
   end
 
   defp read_manifest(path) do
-    case File.read(Path.join(@manifest_path, path)) do
+    case File.read(Path.join(Mix.Project.app_path, path)) do
       {:ok, pos}  -> String.split(pos, "\n", trim: true)
       {:error, _} -> []
     end


### PR DESCRIPTION
This should fix #99.

Right now, the `:gettext` compiler uses a hardcoded default wildcard of `"**/*.po"` to find all the PO files under `priv` (so that manifests can be built and updated). This turns out to be very slow when there are a lot of files in `priv`, as it may happen for example in a Phoenix application with a lot of stuff in `priv/vendor` (see https://github.com/phoenixframework/phoenix/issues/1671).

This commit adds support for the `:compiler_po_wildcard` option to the `:gettext` application. This option specifies the wildcard that the compiler uses  to find PO files (relative to `priv`). It defaults to `gettext/*/LC_MESSAGES/*.po`, which is in line with the default directory for Gettext backends, which is `priv/gettext`.

I'm not 100% sure about the name of this option, but I think it's a start. Wdyt @josevalim?

(on an unrelated note, PR number 100! 🎉)