### PR TITLE
Allow recursive lookup of interpolation keys

### DIFF
--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -47,6 +47,12 @@ defmodule Gettext.InterpolationTest do
            == {:ok, "Hello Alex. Goodbye Alex"}
   end
 
+  test "interpolate/2: nested maps" do
+    assert Interpolation.interpolate("The %{fox.speed} %{fox.color} fox jumps over the %{dog.attitude} dog.",
+                                     %{fox: %{speed: "quick", color: "brown"}, dog: %{attitude: "lazy"}})
+           == {:ok, "The quick brown fox jumps over the lazy dog."}
+  end
+
   test "keys/1" do
     assert Interpolation.keys("Hello %{name}")
            == [:name]


### PR DESCRIPTION
Hi guys, we are using this module in our Phoenix app, and we have some nested models. In some places we want to interpolate information from one or more models into translatable strings. It would be very handy if we did not have to build a intermediate map but could just interpolate like this:
```
gettext("Welcome %{user.first_name} %{user.last_name} to your project %{project.name}", %{user: user, project: project})
```

My pull request would allow just that. What's your opinion on this feature?
Also, what's missing from my pull request? (documentation, more tests)