### PR TITLE
Add missing bindings handler

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -444,6 +444,19 @@ defmodule Gettext do
     quote do
       @gettext_opts unquote(opts)
       @before_compile Gettext.Compiler
+
+      @doc """
+      Default handling for missing bindings.
+
+      If a translated `msgid` does contain a binding that is missing, this method will be called.
+      By default it only logs the error but it can be overwritten.
+      The return value is used instead of the missing binding.
+      """
+      @spec handle_missing_binding(atom, binary, binary) :: binary
+      def handle_missing_binding(binding, original_string, locale) do
+        "%{#{binding}}"
+      end
+      defoverridable handle_missing_binding: 3
     end
   end
 

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -450,9 +450,24 @@ defmodule Gettext do
       @doc """
       Default handling for missing bindings.
 
-      If a translated `msgid` does contain a binding that is missing, this method will be called.
-      By default it only logs the error but it can be overwritten.
-      The return value is used instead of the missing binding.
+      This function is called for every missing binding found in a translation.
+      It takes the `binding` (as an atom), the original translation, and the current locale.
+      The return value of this function is used as replacement for the missing binding.
+      For example, if something like this is called:
+
+          MyApp.Gettext.gettext("Hello %{name}, welcome to %{country}", name: "Jane", country: "Italy")
+
+      and our `it/LC_MESSAGES/default.po` looks like this:
+
+          msgid "Hello %{name}, welcome to %{country}"
+          msgstr "Ciao %{name}, benvenuto in %{cowntry}" # (typo)
+
+      then Gettext will call:
+
+          MyApp.Gettext.handle_missing_binding(:cowntry, "Ciao %{name}, benvenuto in %{cowntry}", "it")
+
+      The default implementation for this function warns about the missing binding and returns `%{binding}` (`%{cowntry}` in the example).
+      This function can be overridden.
       """
       @spec handle_missing_binding(atom, binary, binary) :: binary
       def handle_missing_binding(binding, original_string, locale) do

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -442,6 +442,8 @@ defmodule Gettext do
   @doc false
   defmacro __using__(opts) do
     quote do
+      require Logger
+
       @gettext_opts unquote(opts)
       @before_compile Gettext.Compiler
 
@@ -454,6 +456,7 @@ defmodule Gettext do
       """
       @spec handle_missing_binding(atom, binary, binary) :: binary
       def handle_missing_binding(binding, original_string, locale) do
+        Logger.warn("The key \"#{binding}\" for the translation \"#{original_string}\" (locale #{locale}) is missing from the bindings.")
         "%{#{binding}}"
       end
       defoverridable handle_missing_binding: 3

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -147,8 +147,10 @@ defmodule Gettext.Compiler do
       defp interpolate(str, bindings, locale) do
         Gettext.Interpolation.to_interpolatable(str)
         |> Enum.map_join("", fn
-          segment when is_atom(segment) -> Map.get_lazy(bindings, segment, fn -> handle_missing_binding(segment, str, locale) end)
-          segment                       -> segment
+          segment when is_atom(segment) ->
+            Map.get_lazy(bindings, segment, fn -> handle_missing_binding(segment, str, locale) end)
+          segment ->
+            segment
         end)
       end
     end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -304,8 +304,6 @@ defmodule Gettext.Compiler do
             segment -> segment
           end)
           {:ok, translation}
-        _ ->
-          raise(Gettext.Error, "Bindings must be a map")
       end
     end
   end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -146,12 +146,7 @@ defmodule Gettext.Compiler do
 
       defp interpolate(str, bindings, locale) do
         Gettext.Interpolation.to_interpolatable(str)
-        |> Enum.map_join("", fn
-          segment when is_atom(segment) ->
-            Map.get_lazy(bindings, segment, fn -> handle_missing_binding(segment, str, locale) end)
-          segment ->
-            segment
-        end)
+        |> Gettext.Interpolation.interpolate(bindings, str, locale, &__MODULE__.handle_missing_binding/3)
       end
     end
   end
@@ -299,10 +294,7 @@ defmodule Gettext.Compiler do
         unquote(match) ->
           {:ok, unquote(interpolation)}
         %{} ->
-          translation = Enum.map_join(unquote(interpolatable), "", fn
-            segment when is_atom(segment) -> Map.get_lazy(var!(bindings), segment, fn -> handle_missing_binding(segment, unquote(str), unquote(locale)) end)
-            segment -> segment
-          end)
+          translation = Gettext.Interpolation.interpolate(unquote(interpolatable), var!(bindings), unquote(str), unquote(locale), &__MODULE__.handle_missing_binding/3)
           {:ok, translation}
       end
     end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -277,7 +277,17 @@ defmodule Gettext.Compiler do
   # missing. Note that the `bindings` variable is assumed to be in the scope by
   # the quoted code that is returned.
   defp compile_interpolation(str, locale) do
-    keys           = Interpolation.keys(str)
+    compile_interpolation(str, locale, Interpolation.keys(str))
+  end
+
+  defp compile_interpolation(str, _locale, []=_keys) do
+    quote do
+      _ = var!(bindings)
+      {:ok, unquote(str)}
+    end
+  end
+
+  defp compile_interpolation(str, locale, keys) do
     match          = compile_interpolation_match(keys)
     interpolation  = compile_interpolatable_string(str)
     interpolatable = Interpolation.to_interpolatable(str)

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -280,7 +280,7 @@ defmodule Gettext.Compiler do
     compile_interpolation(str, locale, Interpolation.keys(str))
   end
 
-  defp compile_interpolation(str, _locale, []=_keys) do
+  defp compile_interpolation(str, _locale, [] = _keys) do
     quote do
       _ = var!(bindings)
       {:ok, unquote(str)}
@@ -297,7 +297,7 @@ defmodule Gettext.Compiler do
         unquote(match) ->
           {:ok, unquote(interpolation)}
         %{} ->
-          translation = Enum.map_join(unquote(interpolatable) , "", fn
+          translation = Enum.map_join(unquote(interpolatable), "", fn
             segment when is_atom(segment) -> Map.get_lazy(var!(bindings), segment, fn -> handle_missing_binding(segment, unquote(str), unquote(locale)) end)
             segment -> segment
           end)

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -41,9 +41,14 @@ defmodule Gettext.Interpolation do
   The callback will be called with the missing binding, the original string and the locale.
   See also the default implementation in `Gettext`.
 
-  ## Example
+  ## Examples
 
-      iex> Gettext.Interpolation.interpolate(["Hello ", :name, ", you have ", :count, " unread messages"], %{ :name => "José", :count => 3 }, "Hello %{name}, you have %{count} unread messages", "en_GB", &__MODULE__.handle_missing_binding/3)
+      iex> interpolatable = ["Hello ", :name, ", you have ", :count, " unread messages"]
+      iex> msgid = "Hello %{name}, you have %{count} unread messages"
+      iex> bindings = %{ :name => "José", :count => 3 }
+      iex> locale = "en_GB"
+      iex> handler = fn(binding, _str, _locale) -> Atom.to_string(binding) end
+      iex> Gettext.Interpolation.interpolate(interpolatable, bindings, msgid, locale, handler)
       "Hello José, you have 3 unread messages"
 
   """

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -33,25 +33,6 @@ defmodule Gettext.Interpolation do
   end
 
   @doc """
-  Tells which `required` keys are missing in `bindings`.
-
-  Returns an error message which tells which keys in `required` don't appear in
-  `bindings`.
-
-  ## Examples
-
-      iex> Gettext.Interpolation.missing_interpolation_keys %{foo: 1}, [:foo, :bar, :baz]
-      "missing interpolation keys: bar, baz"
-
-  """
-  @spec missing_interpolation_keys(%{}, [atom]) :: binary
-  def missing_interpolation_keys(bindings, required) do
-    present = Map.keys(bindings)
-    missing = required -- present
-    "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
-  end
-
-  @doc """
   Returns all the interpolation keys contained in the given string or list of
   segments.
 
@@ -80,36 +61,4 @@ defmodule Gettext.Interpolation do
     do: str |> to_interpolatable |> keys
   def keys(segments) when is_list(segments),
     do: Enum.filter(segments, &is_atom/1) |> Enum.uniq
-
-  @doc """
-  Dynimically interpolates `str` with the given `bindings`.
-
-  This function replaces all interpolations (like `%{this}`) inside `str` with
-  the keys contained in `bindings`. It returns `{:ok, str}` if all the
-  interpolation keys in `str` are present in `bindings`, `{:error, msg}`
-  otherwise.
-
-  ## Examples
-
-      iex> Gettext.Interpolation.interpolate "Hello %{name}", %{name: "José"}
-      {:ok, "Hello José"}
-      iex> Gettext.Interpolation.interpolate "%{count} errors", %{name: "Jane"}
-      {:error, "missing interpolation keys: count"}
-
-  """
-  @spec interpolate(binary, %{}) :: {:ok, binary} | {:error, binary}
-  def interpolate(str, bindings) do
-    segments = to_interpolatable(str)
-    keys     = keys(segments)
-
-    if keys -- Map.keys(bindings) != [] do
-      {:error, missing_interpolation_keys(bindings, keys)}
-    else
-      interpolated = Enum.map_join segments, "", fn
-        key when is_atom(key) -> Map.fetch!(bindings, key)
-        other                 -> other
-      end
-      {:ok, interpolated}
-    end
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Gettext.Mixfile do
   end
 
   def application do
-    [applications: [],
+    [applications: [:logger],
      env: [default_locale: "en"]]
   end
 

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -12,41 +12,6 @@ defmodule Gettext.InterpolationTest do
            == [:"Your name", " is cool!"]
   end
 
-  test "missing_interpolation_keys/2" do
-    bindings = %{
-      foo: "foo",
-      bar: "baz",
-    }
-
-    assert Interpolation.missing_interpolation_keys(bindings, [:foo, :bar, :baz])
-           == "missing interpolation keys: baz"
-
-    assert Interpolation.missing_interpolation_keys(bindings, [:foo, :bar, :a, :b, :c])
-           == "missing interpolation keys: a, b, c"
-  end
-
-  test "interpolate/2: successful cases" do
-    assert Interpolation.interpolate("Hello %{name}", %{name: "Alex"})
-           == {:ok, "Hello Alex"}
-    assert Interpolation.interpolate("%{count} errors", %{count: 3})
-           == {:ok, "3 errors"}
-  end
-
-  test "interpolate/2: missing bindings" do
-    assert Interpolation.interpolate("Hi %{name}", %{})
-           == {:error, "missing interpolation keys: name"}
-  end
-
-  test "interpolate/2: unused bindings are ignored" do
-    assert Interpolation.interpolate("Hi %{name}", %{name: "Sandra", foo: "bar"})
-           == {:ok, "Hi Sandra"}
-  end
-
-  test "interpolate/2: repeated bindings" do
-    assert Interpolation.interpolate("Hello %{name}. Goodbye %{name}", %{name: "Alex"})
-           == {:ok, "Hello Alex. Goodbye Alex"}
-  end
-
   test "keys/1" do
     assert Interpolation.keys("Hello %{name}")
            == [:name]

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -183,7 +183,7 @@ defmodule GettextTest do
 
     msgid = "Hello %{name}"
     assert Translator.lgettext("pl", "foo", msgid, %{})
-           == {:error, "missing interpolation keys: name"}
+           == {:default, "Hello %{name}"}
   end
 
   test "lngettext/6: default handle_missing_binding preserves key" do

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -169,10 +169,10 @@ defmodule GettextTest do
 
   test "lgettext/4: default handle_missing_binding preserves key" do
     msgid = "My name is %{name} and I'm %{age}"
-    assert capture_log(fn ->
-      assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"})
-      == {:ok, "Mi chiamo José e ho %{age} anni"}
-    end) =~ ~s[The key "age" for the translation "Mi chiamo %{name} e ho %{age} anni" (locale it) is missing from the bindings.]
+    log = capture_log(fn ->
+      assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"}) == {:ok, "Mi chiamo José e ho %{age} anni"}
+    end)
+    assert log =~ ~s[The key "age" for the translation "Mi chiamo %{name} e ho %{age} anni" (locale it) is missing from the bindings.]
   end
 
   test "lgettext/4: interpolation works when a translation is missing" do
@@ -184,26 +184,26 @@ defmodule GettextTest do
     assert Translator.lgettext("pl", "foo", msgid, %{})
            == {:default, "Hello world!"}
 
-    assert capture_log(fn ->
+    log = capture_log(fn ->
       msgid = "Hello %{name}"
-      assert Translator.lgettext("pl", "foo", msgid, %{})
-      == {:default, "Hello %{name}"}
-    end) =~ ~s[The key "name" for the translation "Hello %{name}" (locale pl) is missing from the bindings.]
+      assert Translator.lgettext("pl", "foo", msgid, %{}) == {:default, "Hello %{name}"}
+    end)
+    assert log =~ ~s[The key "name" for the translation "Hello %{name}" (locale pl) is missing from the bindings.]
   end
 
   test "lngettext/6: default handle_missing_binding preserves key" do
     msgid =  "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
 
-    assert capture_log(fn ->
-      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{})
-      == {:ok, "Hai un messaggio, %{name}"}
-    end) =~ ~s[The key "name" for the translation "Hai un messaggio, %{name}" (locale it) is missing from the bindings.]
+    log = capture_log(fn ->
+      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{}) == {:ok, "Hai un messaggio, %{name}"}
+    end)
+    assert log =~ ~s[The key "name" for the translation "Hai un messaggio, %{name}" (locale it) is missing from the bindings.]
 
-    assert capture_log(fn ->
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6, %{})
-      == {:ok, "Hai 6 messaggi, %{name}"}
-      end) =~ ~s[The key "name" for the translation "Hai %{count} messaggi, %{name}" (locale it) is missing from the bindings.]
+    log = capture_log(fn ->
+      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6, %{}) == {:ok, "Hai 6 messaggi, %{name}"}
+    end)
+    assert log =~ ~s[The key "name" for the translation "Hai %{count} messaggi, %{name}" (locale it) is missing from the bindings.]
   end
 
   test "lngettext/6: interpolation works when a translation is missing" do
@@ -224,10 +224,10 @@ defmodule GettextTest do
     assert Translator.dgettext("interpolations", "Hello %{name}", keys)
            == "Ciao Jim"
 
-    assert capture_log(fn ->
-      assert Translator.dgettext("interpolations", "Hello %{name}")
-      == "Ciao %{name}"
-    end) =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
+    log = capture_log(fn ->
+      assert Translator.dgettext("interpolations", "Hello %{name}") == "Ciao %{name}"
+    end)
+    assert log =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
   end
 
   # Macros.
@@ -321,9 +321,10 @@ defmodule GettextTest do
 
     assert Gettext.dgettext(Translator, "foo", "Foo") == "Foo"
 
-    assert capture_log(fn ->
+    log = capture_log(fn ->
       assert Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{}) == "Ciao %{name}"
-    end) =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
+    end)
+    assert log =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
   end
 
   test "gettext/3" do

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -22,6 +22,7 @@ defmodule GettextTest do
   use ExUnit.Case
 
   import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
 
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
@@ -168,8 +169,10 @@ defmodule GettextTest do
 
   test "lgettext/4: default handle_missing_binding preserves key" do
     msgid = "My name is %{name} and I'm %{age}"
-    assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"})
-           == {:ok, "Mi chiamo José e ho %{age} anni"}
+    assert capture_log(fn ->
+      assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"})
+      == {:ok, "Mi chiamo José e ho %{age} anni"}
+    end) =~ ~s[The key "age" for the translation "Mi chiamo %{name} e ho %{age} anni" (locale it) is missing from the bindings.]
   end
 
   test "lgettext/4: interpolation works when a translation is missing" do
@@ -181,20 +184,26 @@ defmodule GettextTest do
     assert Translator.lgettext("pl", "foo", msgid, %{})
            == {:default, "Hello world!"}
 
-    msgid = "Hello %{name}"
-    assert Translator.lgettext("pl", "foo", msgid, %{})
-           == {:default, "Hello %{name}"}
+    assert capture_log(fn ->
+      msgid = "Hello %{name}"
+      assert Translator.lgettext("pl", "foo", msgid, %{})
+      == {:default, "Hello %{name}"}
+    end) =~ ~s[The key "name" for the translation "Hello %{name}" (locale pl) is missing from the bindings.]
   end
 
   test "lngettext/6: default handle_missing_binding preserves key" do
     msgid =  "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
 
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
-           == {:ok, "Hai un messaggio, %{name}"}
+    assert capture_log(fn ->
+      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
+      == {:ok, "Hai un messaggio, %{name}"}
+    end) =~ ~s[The key "name" for the translation "Hai un messaggio, %{name}" (locale it) is missing from the bindings.]
 
+    assert capture_log(fn ->
     assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6)
-           == {:ok, "Hai 6 messaggi, %{name}"}
+      == {:ok, "Hai 6 messaggi, %{name}"}
+      end) =~ ~s[The key "name" for the translation "Hai %{count} messaggi, %{name}" (locale it) is missing from the bindings.]
   end
 
   test "lngettext/6: interpolation works when a translation is missing" do
@@ -215,8 +224,10 @@ defmodule GettextTest do
     assert Translator.dgettext("interpolations", "Hello %{name}", keys)
            == "Ciao Jim"
 
-    assert Translator.dgettext("interpolations", "Hello %{name}")
-           == "Ciao %{name}"
+    assert capture_log(fn ->
+      assert Translator.dgettext("interpolations", "Hello %{name}")
+      == "Ciao %{name}"
+    end) =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
   end
 
   # Macros.
@@ -310,7 +321,9 @@ defmodule GettextTest do
 
     assert Gettext.dgettext(Translator, "foo", "Foo") == "Foo"
 
-    assert Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{}) == "Ciao %{name}"
+    assert capture_log(fn ->
+      assert Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{}) == "Ciao %{name}"
+    end) =~ ~s[The key "name" for the translation "Ciao %{name}" (locale it) is missing from the bindings.]
   end
 
   test "gettext/3" do

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -196,12 +196,12 @@ defmodule GettextTest do
     msgid_plural = "You have %{count} messages, %{name}"
 
     assert capture_log(fn ->
-      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
+      assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{})
       == {:ok, "Hai un messaggio, %{name}"}
     end) =~ ~s[The key "name" for the translation "Hai un messaggio, %{name}" (locale it) is missing from the bindings.]
 
     assert capture_log(fn ->
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6)
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6, %{})
       == {:ok, "Hai 6 messaggi, %{name}"}
       end) =~ ~s[The key "name" for the translation "Hai %{count} messaggi, %{name}" (locale it) is missing from the bindings.]
   end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -166,10 +166,10 @@ defmodule GettextTest do
            == {:ok, "Un amico"}
   end
 
-  test "lgettext/4: error when keys are missing in an interpolation" do
+  test "lgettext/4: default handle_missing_binding preserves key" do
     msgid = "My name is %{name} and I'm %{age}"
     assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"})
-           == {:error, "missing interpolation keys: age"}
+           == {:ok, "Mi chiamo José e ho %{age} anni"}
   end
 
   test "lgettext/4: interpolation works when a translation is missing" do
@@ -186,15 +186,15 @@ defmodule GettextTest do
            == {:error, "missing interpolation keys: name"}
   end
 
-  test "lngettext/6: error when keys are missing in an interpolation" do
+  test "lngettext/6: default handle_missing_binding preserves key" do
     msgid =  "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
 
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{})
-           == {:error, "missing interpolation keys: name"}
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
+           == {:ok, "Hai un messaggio, %{name}"}
 
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6, %{})
-           == {:error, "missing interpolation keys: name"}
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6)
+           == {:ok, "Hai 6 messaggi, %{name}"}
   end
 
   test "lngettext/6: interpolation works when a translation is missing" do
@@ -215,10 +215,8 @@ defmodule GettextTest do
     assert Translator.dgettext("interpolations", "Hello %{name}", keys)
            == "Ciao Jim"
 
-    msg = "missing interpolation keys: name"
-    assert_raise Gettext.Error, msg, fn ->
-      Translator.dgettext("interpolations", "Hello %{name}")
-    end
+    assert Translator.dgettext("interpolations", "Hello %{name}")
+           == "Ciao %{name}"
   end
 
   # Macros.
@@ -312,10 +310,7 @@ defmodule GettextTest do
 
     assert Gettext.dgettext(Translator, "foo", "Foo") == "Foo"
 
-    msg = "missing interpolation keys: name"
-    assert_raise Gettext.Error, msg, fn ->
-      Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{})
-    end
+    assert Gettext.dgettext(Translator, "interpolations", "Hello %{name}", %{}) == "Ciao %{name}"
   end
 
   test "gettext/3" do


### PR DESCRIPTION
This is far from finished but I struggle with the meta programming, so I just open the discussion here.
When running the tests, I get an error that I do not understand.
```
  1) test lngettext/6: default handle_missing_binding preserves key (GettextTest)
     test/gettext_test.exs:189
     ** (ArgumentError) argument error
     stacktrace:
       :erlang.bit_size(6)
       test/gettext_test.exs:1: anonymous fn/2 in GettextTest.Translator.lngettext/6
       (elixir) lib/enum.ex:1473: Enum."-reduce/3-lists^foldl/2-0-"/3
       test/gettext_test.exs:1: GettextTest.Translator.lngettext/6
       test/gettext_test.exs:196
```