### PR TITLE
Handle non-map bindings in the l(n)gettext functions

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -513,13 +513,7 @@ defmodule Gettext do
   """
   @spec dgettext(module, binary, binary, bindings) :: binary
   def dgettext(backend, domain, msgid, bindings \\ %{})
-
-  def dgettext(backend, domain, msgid, bindings) when is_list(bindings) do
-    dgettext(backend, domain, msgid, Enum.into(bindings, %{}))
-  end
-
-  def dgettext(backend, domain, msgid, bindings)
-      when is_atom(backend) and is_binary(domain) and is_binary(msgid) and is_map(bindings) do
+      when is_atom(backend) and is_binary(domain) and is_binary(msgid) do
     backend.lgettext(get_locale(backend), domain, msgid, bindings)
     |> handle_backend_result
   end
@@ -564,14 +558,8 @@ defmodule Gettext do
   """
   @spec dngettext(module, binary, binary, binary, non_neg_integer, bindings) :: binary
   def dngettext(backend, domain, msgid, msgid_plural, n, bindings \\ %{})
-
-  def dngettext(backend, domain, msgid, msgid_plural, n, bindings) when is_list(bindings) do
-    dngettext(backend, domain, msgid, msgid_plural, n, Enum.into(bindings, %{}))
-  end
-
-  def dngettext(backend, domain, msgid, msgid_plural, n, bindings)
       when is_atom(backend) and is_binary(domain) and is_binary(msgid) and
-           is_binary(msgid_plural) and is_integer(n) and is_map(bindings) do
+           is_binary(msgid_plural) and is_integer(n) do
     backend.lngettext(get_locale(backend), domain, msgid, msgid_plural, n, bindings)
     |> handle_backend_result
   end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -122,6 +122,14 @@ defmodule Gettext.Compiler do
     quote do
       def lgettext(locale, domain, msgid, bindings \\ %{})
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings \\ %{})
+
+      def lgettext(locale, domain, msgid, bindings) when is_list(bindings) do
+        lgettext(locale, domain, msgid, Enum.into(bindings, %{}))
+      end
+
+      def lngettext(locale, domain, msgid, msgid_plural, n, bindings) when is_list(bindings) do
+        lngettext(locale, domain, msgid, msgid_plural, n, Enum.into(bindings, %{}))
+      end
     end
   end
 

--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -46,7 +46,7 @@ defmodule Gettext.Interpolation do
   """
   @spec missing_interpolation_keys(%{}, [atom]) :: binary
   def missing_interpolation_keys(bindings, required) do
-    present = Enum.map(bindings, &elem(&1, 0))
+    present = Map.keys(bindings)
     missing = required -- present
     "missing interpolation keys: " <> Enum.map_join(missing, ", ", &to_string/1)
   end


### PR DESCRIPTION
\cc @josevalim, this should be enough to handle all the `bindings` types :) Wdyt?