### PR TITLE
Only check for the type of bindings in Gettext.*gettext functions

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -528,7 +528,13 @@ defmodule Gettext do
   """
   @spec dgettext(module, binary, binary, bindings) :: binary
   def dgettext(backend, domain, msgid, bindings \\ %{})
-      when is_atom(backend) and is_binary(domain) and is_binary(msgid) do
+
+  def dgettext(backend, domain, msgid, bindings) when is_list(bindings) do
+    dgettext(backend, domain, msgid, :maps.from_list(bindings))
+  end
+
+  def dgettext(backend, domain, msgid, bindings)
+      when is_atom(backend) and is_binary(domain) and is_binary(msgid) and is_map(bindings) do
     backend.lgettext(get_locale(backend), domain, msgid, bindings)
     |> handle_backend_result
   end
@@ -573,8 +579,15 @@ defmodule Gettext do
   """
   @spec dngettext(module, binary, binary, binary, non_neg_integer, bindings) :: binary
   def dngettext(backend, domain, msgid, msgid_plural, n, bindings \\ %{})
+
+  def dngettext(backend, domain, msgid, msgid_plural, n, bindings) when is_list(bindings) do
+    dngettext(backend, domain, msgid, msgid_plural, n, :maps.from_list(bindings))
+  end
+
+  def dngettext(backend, domain, msgid, msgid_plural, n, bindings)
       when is_atom(backend) and is_binary(domain) and is_binary(msgid) and
-           is_binary(msgid_plural) and is_integer(n) do
+           is_binary(msgid_plural) and is_integer(n) and n >= 0 and
+           is_map(bindings) do
     backend.lngettext(get_locale(backend), domain, msgid, msgid_plural, n, bindings)
     |> handle_backend_result
   end

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -120,19 +120,11 @@ defmodule Gettext.Compiler do
   @spec signatures() :: Macro.t
   def signatures do
     quote do
-      @spec lgettext(binary, binary, binary, term) :: {:default, binary} | {:error, term}
-      def lgettext(locale, domain, msgid, bindings \\ %{})
+      @spec lgettext(binary, binary, binary, %{}) :: {:default, binary} | {:error, term}
+      def lgettext(locale, domain, msgid, bindings)
 
-      @spec lngettext(binary, binary, binary, binary, non_neg_integer, term) :: {:default, binary} | {:error, term}
-      def lngettext(locale, domain, msgid, msgid_plural, n, bindings \\ %{})
-
-      def lgettext(locale, domain, msgid, bindings) when is_list(bindings) do
-        lgettext(locale, domain, msgid, Enum.into(bindings, %{}))
-      end
-
-      def lngettext(locale, domain, msgid, msgid_plural, n, bindings) when is_list(bindings) do
-        lngettext(locale, domain, msgid, msgid_plural, n, Enum.into(bindings, %{}))
-      end
+      @spec lngettext(binary, binary, binary, binary, non_neg_integer, %{}) :: {:default, binary} | {:error, term}
+      def lngettext(locale, domain, msgid, msgid_plural, n, bindings)
     end
   end
 

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -57,62 +57,62 @@ defmodule GettextTest do
   end
 
   test "found translations return {:ok, translation}" do
-    assert Translator.lgettext("it", "default", "Hello world")
+    assert Translator.lgettext("it", "default", "Hello world", %{})
            == {:ok, "Ciao mondo"}
 
-    assert Translator.lgettext("it", "errors", "Invalid email address")
+    assert Translator.lgettext("it", "errors", "Invalid email address", %{})
            == {:ok, "Indirizzo email non valido"}
   end
 
   test "non-found translations return the argument message" do
     # Unknown msgid.
-    assert Translator.lgettext("it", "default", "nonexistent")
+    assert Translator.lgettext("it", "default", "nonexistent", %{})
            == {:default, "nonexistent"}
 
     # Unknown domain.
-    assert Translator.lgettext("it", "unknown", "Hello world")
+    assert Translator.lgettext("it", "unknown", "Hello world", %{})
            == {:default, "Hello world"}
 
     # Unknown locale.
-    assert Translator.lgettext("pt_BR", "nonexistent", "Hello world")
+    assert Translator.lgettext("pt_BR", "nonexistent", "Hello world", %{})
            == {:default, "Hello world"}
   end
 
   test "translations with empty msgstrs fallback to {:default, _}" do
-    assert Translator.lgettext("it", "default", "Empty msgstr!")
+    assert Translator.lgettext("it", "default", "Empty msgstr!", %{})
            == {:default, "Empty msgstr!"}
   end
 
   test "a custom 'priv' directory can be used to store translations" do
-    assert TranslatorWithCustomPriv.lgettext("it", "default", "Hello world")
+    assert TranslatorWithCustomPriv.lgettext("it", "default", "Hello world", %{})
            == {:ok, "Ciao mondo"}
 
-    assert TranslatorWithCustomPriv.lgettext("it", "errors", "Invalid email address")
+    assert TranslatorWithCustomPriv.lgettext("it", "errors", "Invalid email address", %{})
            == {:ok, "Indirizzo email non valido"}
   end
 
   test "using a custom Gettext.Plural module" do
     alias TranslatorWithCustomPluralForms, as: T
-    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 1) ==
+    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 1, %{}) ==
            {:ok, "1 nuove email"}
-    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 2) ==
+    assert T.lngettext("it", "default", "One new email", "%{count} new emails", 2, %{}) ==
            {:ok, "Una nuova email"}
   end
 
   test "translations can be pluralized" do
-    import Translator, only: [lngettext: 5]
+    import Translator, only: [lngettext: 6]
 
-    t = lngettext("it", "errors", "There was an error", "There were %{count} errors", 1)
+    t = lngettext("it", "errors", "There was an error", "There were %{count} errors", 1, %{})
     assert t == {:ok, "C'è stato un errore"}
 
-    t = lngettext("it", "errors", "There was an error", "There were %{count} errors", 3)
+    t = lngettext("it", "errors", "There was an error", "There were %{count} errors", 3, %{})
     assert t == {:ok, "Ci sono stati 3 errori"}
   end
 
   test "by default, non-found pluralized translation behave like regular translation" do
-    assert Translator.lngettext("it", "not a domain", "foo", "foos", 1)
+    assert Translator.lngettext("it", "not a domain", "foo", "foos", 1, %{})
            == {:default, "foo"}
-    assert Translator.lngettext("it", "not a domain", "foo", "foos", 10)
+    assert Translator.lngettext("it", "not a domain", "foo", "foos", 10, %{})
            == {:default, "foos"}
   end
 
@@ -120,9 +120,9 @@ defmodule GettextTest do
     msgid        = "Not even one msgstr"
     msgid_plural = "Not even %{count} msgstrs"
 
-    assert Translator.lngettext("it", "default", msgid, msgid_plural, 1)
+    assert Translator.lngettext("it", "default", msgid, msgid_plural, 1, %{})
            == {:default, "Not even one msgstr"}
-    assert Translator.lngettext("it", "default", msgid, msgid_plural, 2)
+    assert Translator.lngettext("it", "default", msgid, msgid_plural, 2, %{})
            == {:default, "Not even 2 msgstrs"}
   end
 
@@ -142,9 +142,9 @@ defmodule GettextTest do
   test "interpolation is supported by lngettext" do
     msgid        = "There was an error"
     msgid_plural = "There were %{count} errors"
-    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 1)
+    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 1, %{})
            == {:ok, "C'è stato un errore"}
-    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 4)
+    assert Translator.lngettext("it", "errors", msgid, msgid_plural, 4, %{})
            == {:ok, "Ci sono stati 4 errori"}
 
     msgid        = "You have one message, %{name}"
@@ -157,7 +157,7 @@ defmodule GettextTest do
 
   test "strings are concatenated before generating function clauses" do
     msgid = "Concatenated and long string"
-    assert Translator.lgettext("it", "default", msgid)
+    assert Translator.lgettext("it", "default", msgid, %{})
            == {:ok, "Stringa lunga e concatenata"}
 
     msgid        = "A friend"
@@ -168,7 +168,7 @@ defmodule GettextTest do
 
   test "lgettext/4: error when keys are missing in an interpolation" do
     msgid = "My name is %{name} and I'm %{age}"
-    assert Translator.lgettext("it", "interpolations", msgid, name: "José")
+    assert Translator.lgettext("it", "interpolations", msgid, %{name: "José"})
            == {:error, "missing interpolation keys: age"}
   end
 
@@ -178,7 +178,7 @@ defmodule GettextTest do
            == {:default, "Hello Samantha, missing translation!"}
 
     msgid = "Hello world!"
-    assert Translator.lgettext("pl", "foo", msgid)
+    assert Translator.lgettext("pl", "foo", msgid, %{})
            == {:default, "Hello world!"}
 
     msgid = "Hello %{name}"
@@ -190,19 +190,19 @@ defmodule GettextTest do
     msgid =  "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
 
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1)
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{})
            == {:error, "missing interpolation keys: name"}
 
-    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6)
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 6, %{})
            == {:error, "missing interpolation keys: name"}
   end
 
   test "lngettext/6: interpolation works when a translation is missing" do
     msgid        = "One error"
     msgid_plural = "%{count} errors"
-    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 1)
+    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 1, %{})
            == {:default, "One error"}
-    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 9)
+    assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 9, %{})
            == {:default, "9 errors"}
   end
 


### PR DESCRIPTION
`l*gettext` functions generated in backends will now assume bindings are a map and the only conversion from keyword list to map will be performed in `Gettext.*gettext` functions. These functions are used by the `*gettext` macros generated in each backend as well, so each case will be covered.

@josevalim wdyt of this? We were using `bindings \\ %{}` in `l*gettext` functions but those are never called directly (except in tests), so I think being stricter makes sense there. Also typespecs should be a bit clearer this way (related to #115 which I'm trying to fix).