### PR TITLE
Move some function generation from Gettext to Gettext.Compiler

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -444,7 +444,6 @@ defmodule Gettext do
     quote do
       @gettext_opts unquote(opts)
       @before_compile Gettext.Compiler
-      unquote(Gettext.Compiler.signatures)
     end
   end
 

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -53,6 +53,7 @@ defmodule Gettext.Compiler do
       end
 
       unquote(macros())
+      unquote(signatures())
       unquote(compile_po_files(translations_dir))
       unquote(dynamic_clauses())
     end
@@ -114,11 +115,7 @@ defmodule Gettext.Compiler do
     end
   end
 
-  @doc """
-  Returns the function signatures of `lgettext/4` and `lngettext/6`.
-  """
-  @spec signatures() :: Macro.t
-  def signatures do
+  defp signatures do
     quote do
       def lgettext(locale, domain, msgid, bindings)
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings)


### PR DESCRIPTION
@josevalim I remember we decided to keep the call to `Gettext.Compiler.signatures/0` in `Gettext.__using__/1` but now I don't really see the point 😕 It makes it a bit harder to follow the whole flow since that call is far from the rest of related calls to `Gettext.Compiler.dynamic_clauses/0` and friends. Wdyt?