### PR TITLE
Define *gettext_noop macros that mark translations for extraction

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -129,6 +129,7 @@ defmodule Gettext do
     * `dgettext/3`
     * `ngettext/4`
     * `dngettext/5`
+    * `gettext_noop/1`, `dgettext_noop/2`, `ngettext_noop/3`, `dngettext_noop/4`
 
   Supposing the caller module is `MyApp.Gettext`, the macros mentioned above
   behave as follows:
@@ -141,6 +142,12 @@ defmodule Gettext do
       like `Gettext.ngettext(MyApp.Gettext, msgid, msgid_plural, n, bindings)`
     * `dngettext(domain, msgid, msgid_plural, n, bindings \\ %{})` -
       like `Gettext.dngettext(MyApp.Gettext, domain, msgid, msgid_plural, n, bindings)`
+    * `*_noop` family of functions - used to mark translations for extraction
+      without translating them; see the documentation for these macros in
+      `Gettext.Backend`
+
+  See also the `Gettext.Backend` behaviour for more detailed documentation about
+  these macros.
 
   Using macros is preferred as gettext is able to automatically sync the
   translations in your code with PO files. This, however, imposes a constraint:

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -133,10 +133,9 @@ defmodule Gettext.Backend do
   @doc """
   Marks the given translation for extraction and returns it unchanged.
 
-  This macro can be used to mark a translation for extraction so that it is
-  extracted when `mix gettext.extract` is run. The return value is the given
-  string, so that this macro can be used seamlessly in place of the string to
-  extract.
+  This macro can be used to mark a translation for extraction when `mix
+  gettext.extract` is run. The return value is the given string, so that this
+  macro can be used seamlessly in place of the string to extract.
 
   ## Examples
 
@@ -147,16 +146,17 @@ defmodule Gettext.Backend do
   @macrocallback dgettext_noop(domain :: String.t, msgid :: String.t) :: Macro.t
 
   @doc """
-  Same as `dgettext_noop("default", msgid).
+  Same as `dgettext_noop("default", msgid)`.
   """
   @macrocallback gettext_noop(msgid :: String.t) :: Macro.t
 
   @doc """
-  Marks the given translation for extract and returns `{msgid, msgid_plural}`.
+  Marks the given translation for extraction and returns
+  `{msgid, msgid_plural}`.
 
-  This macro can be used to mark a translation for extract so that it is
-  extracted when the `mix gettext.extract` Mix task is run. The return value of
-  this macro is `{msgid, msgid_plural}`.
+  This macro can be used to mark a translation for extraction when `mix
+  gettext.extract` is run. The return value of this macro is `{msgid,
+  msgid_plural}`.
 
   ## Examples
 

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -129,4 +129,50 @@ defmodule Gettext.Backend do
   @macrocallback ngettext(msgid :: String.t,
                           msgid_plural :: String.t,
                           n :: Macro.t) :: Macro.t
+
+  @doc """
+  Marks the given translation for extraction and returns it unchanged.
+
+  This macro can be used to mark a translation for extraction so that it is
+  extracted when `mix gettext.extract` is run. The return value is the given
+  string, so that this macro can be used seamlessly in place of the string to
+  extract.
+
+  ## Examples
+
+      MyApp.Gettext.dgettext_noop("errors", "Error found!")
+      #=> "Error found!"
+
+  """
+  @macrocallback dgettext_noop(domain :: String.t, msgid :: String.t) :: Macro.t
+
+  @doc """
+  Same as `dgettext_noop("default", msgid).
+  """
+  @macrocallback gettext_noop(msgid :: String.t) :: Macro.t
+
+  @doc """
+  Marks the given translation for extract and returns `{msgid, msgid_plural}`.
+
+  This macro can be used to mark a translation for extract so that it is
+  extracted when the `mix gettext.extract` Mix task is run. The return value of
+  this macro is `{msgid, msgid_plural}`.
+
+  ## Examples
+
+      my_fun = fn {msgid, msgid_plural} ->
+        # do something with msgid and msgid_plural
+      end
+
+      my_fun.(MyApp.Gettext.dngettext_noop("errors", "One error", "%{count} errors"))
+
+  """
+  @macrocallback dngettext_noop(domain :: Macro.t,
+                                msgid :: String.t,
+                                msgid_plural :: String.t) :: Macro.t
+
+  @doc """
+  Same as `dngettext_noop("default", msgid, mgsid_plural)`.
+  """
+  @macrocallback ngettext_noop(msgid :: String.t, msgid_plural :: String.t) :: String.t
 end

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -299,6 +299,18 @@ defmodule GettextTest do
     assert Translator.gettext("%{msg}", msg: "foo") == "foo"
   end
 
+  test "(d)gettext_noop" do
+    assert Translator.dgettext_noop("errors", "Oops") == "Oops"
+    assert Translator.gettext_noop("Hello %{name}!") == "Hello %{name}!"
+  end
+
+  test "n(d)gettext_noop" do
+    assert Translator.dngettext_noop("errors", "One error", "%{count} errors")
+           == {"One error", "%{count} errors"}
+
+    assert Translator.ngettext_noop("One message", "%{count} messages")
+           == {"One message", "%{count} messages"}
+  end
 
   # Actual Gettext functions (not the ones generated in the modules that `use
   # Gettext`).


### PR DESCRIPTION
Would close #131.

\cc @manukall

@josevalim I went with this approach in `*ngettext_noop` where `{msgid, msgid_plural}` is returned because that is what is often used to represent a plural translation (in Ecto for example, I think right?) and because the Wordpress implementation of these functions (one of the few I found) does the same (returns every info you pass to it basically). The Python implementation seems to ask for `n` as well and does the English pluralization rule, but of the two I think I prefer the tuple one. Wdyt?