### PR TITLE
Parse msgctxt when present but ignore it

### DIFF
--- a/lib/gettext/po/tokenizer.ex
+++ b/lib/gettext/po/tokenizer.ex
@@ -12,6 +12,7 @@ defmodule Gettext.PO.Tokenizer do
     {:msgid, line} |
     {:msgid_plural, line} |
     {:msgstr, line} |
+    {:msgctxt, line} |
     {:comment, line, binary}
 
 
@@ -23,6 +24,7 @@ defmodule Gettext.PO.Tokenizer do
   @keywords ~w(
     msgid_plural
     msgid
+    msgctxt
   )
 
   @whitespace [?\n, ?\t, ?\r, ?\s]

--- a/src/gettext_po_parser.yrl
+++ b/src/gettext_po_parser.yrl
@@ -1,6 +1,6 @@
 Nonterminals grammar translations translation pluralizations pluralization
-             strings comments.
-Terminals str msgid msgid_plural msgstr plural_form comment.
+             strings comments maybe_msgctxt.
+Terminals str msgid msgid_plural msgctxt msgstr plural_form comment.
 Rootsymbol grammar.
 
 grammar ->
@@ -16,19 +16,19 @@ translations ->
   comments translation translations : [add_comments_to_translation('$2', '$1')|'$3'].
 
 translation ->
-  msgid strings msgstr strings : {translation, #{
+  maybe_msgctxt msgid strings msgstr strings : {translation, #{
     comments       => [],
-    msgid          => '$2',
-    msgstr         => '$4',
-    po_source_line => extract_line('$1')
+    msgid          => '$3',
+    msgstr         => '$5',
+    po_source_line => extract_line('$2')
   }}.
 translation ->
-  msgid strings msgid_plural strings pluralizations : {plural_translation, #{
+  maybe_msgctxt msgid strings msgid_plural strings pluralizations : {plural_translation, #{
     comments       => [],
-    msgid          => '$2',
-    msgid_plural   => '$4',
-    msgstr         => plural_forms_map_from_list('$5'),
-    po_source_line => extract_line('$1')
+    msgid          => '$3',
+    msgid_plural   => '$5',
+    msgstr         => plural_forms_map_from_list('$6'),
+    po_source_line => extract_line('$2')
   }}.
 
 pluralizations ->
@@ -49,6 +49,11 @@ comments ->
 comments ->
   comment comments : [extract_simple_token('$1')|'$2'].
 
+%% For now, we ignore the msgctxt.
+maybe_msgctxt ->
+  '$empty' : [].
+maybe_msgctxt ->
+  msgctxt strings : [].
 
 Erlang code.
 

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -294,6 +294,27 @@ defmodule Gettext.PO.ParserTest do
     } = parsed
   end
 
+  test "msgctxt is parsed correctly but ignored" do
+    parsed = Parser.parse([
+      {:msgctxt, 1}, {:str, 1, "my_"}, {:str, 1, "context"},
+      {:msgid, 2}, {:str, 2, "my_msgid"},
+      {:msgstr, 3}, {:str, 3, "my_msgstr"},
+    ])
+
+    assert {:ok, [], [], [%Translation{} = translation]} = parsed
+    assert translation.msgid == ["my_msgid"]
+    assert translation.msgstr == ["my_msgstr"]
+
+    # Badly placed msgctxt still causes a syntax error
+    parsed = Parser.parse([
+      {:msgid, 1}, {:str, 1, "my_msgid"},
+      {:msgctxt, 2}, {:str, 2, "my_context"},
+      {:msgstr, 3}, {:str, 3, "my_msgstr"},
+    ])
+
+    assert parsed == {:error, 2, "syntax error before: msgctxt"}
+  end
+
   test "tokens are printed as Elixir terms, not Erlang terms" do
     parsed = Parser.parse([
       {:msgid, 1}, {:str, 1, ""},

--- a/test/gettext/po/tokenizer_test.exs
+++ b/test/gettext/po/tokenizer_test.exs
@@ -16,6 +16,12 @@ defmodule Gettext.PO.TokenizerTest do
       {:msgid_plural, 1},
       {:msgstr, 1},
     ]}
+
+    str = "msgctxt msgid "
+    assert tokenize(str) == {:ok, [
+      {:msgctxt, 1},
+      {:msgid, 1},
+    ]}
   end
 
   test "keywords must be followed by a space" do


### PR DESCRIPTION
This is a first shot at #142, where I implement support for parsing translations with `msgctxt`, but completely ignoring such context when parsed:

```pot
msgctxt "my context"
msgid "foo"
msgstr "bar"
```

I think as a first step it's good to have this. It ensures we are able to parse files from different editors and such, and this is good. At the same time, we don't change the output currently dumped by Gettext; after all, the use case in #142 is to not fail on files that have `msgctxt`, but not use Gettext to generate such files. I'd love some opinions! :)

Btw, we could start supporting msgctxt but me and @josevalim discussed this a long time ago and decided it was not worth it. It would bring a lot of changes, so it's something that if we consider, we should think about a lot.

(Closes #142)