### PR TITLE
Support of compiler_po_wildcard option in Gettext.Compiler

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -393,6 +393,9 @@ defmodule Gettext do
       "mix compile.gettext" won't work as expected. By default it's
       `"priv/gettext"`.
 
+    * `:compiler_po_wildcard` - allows to explicitly choose the po files that
+      are tracked by the compiler. By default it's `"gettext/*/LC_MESSAGES/*.po"`
+
     * `:plural_forms` - a module which will act as a "pluralizer". For more
       information, look at the documentation for `Gettext.Plural`.
 


### PR DESCRIPTION
Useful to spend less RAM in dev during compilation
The code looks a litlle bit tricky because of different po_wildcard format in Mix.Tasks.Compile.Gettext and Gettext.Compiler