### PR TITLE
Test on Elixir 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ matrix:
   include:
     - otp_release: 18.3
       elixir: 1.2.6
-    - otp_release: 18.3
-      elixir: 1.3.4
-    - otp_release: 19.1
-      elixir: 1.3.4
+    - otp_release: 19.2
+      elixir: 1.4.0
 
 sudo:
   false


### PR DESCRIPTION
I also updated the .travis.yml to match elixir-lang/ex_doc#656 so that only the newest and oldest Elixir/OTP pairs are tested.