### PR TITLE
Warn when compiling and raise at runtime for missing plural forms

### DIFF
--- a/test/fixtures/test_application/bad_translations/ru/LC_MESSAGES/errors.po
+++ b/test/fixtures/test_application/bad_translations/ru/LC_MESSAGES/errors.po
@@ -1,0 +1,5 @@
+# Russian has 3 plural forms, only 2 are defined here.
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "Требуется минимум один символ"
+msgstr[1] "Требуется минимум %{count} символов"


### PR DESCRIPTION
If a translation for a given locale now is missing one or more plural forms for that locale, we will warn when compiling the Gettext backend and raise at runtime if the user tries to use the missing plural form.