### PR TITLE
flags can be separated by [, ]+

### DIFF
--- a/lib/gettext/po.ex
+++ b/lib/gettext/po.ex
@@ -280,8 +280,8 @@ defmodule Gettext.PO do
       flags =
         flags
         |> Enum.sort
-        |> Enum.map(&[?\s, &1])
-      ["#,", flags, ?\n]
+        |> Enum.intersperse(", ")
+      ["#, ", flags, ?\n]
     end
   end
 

--- a/lib/gettext/po/parser.ex
+++ b/lib/gettext/po/parser.ex
@@ -75,7 +75,7 @@ defmodule Gettext.PO.Parser do
   defp parse_flags(flag_comments) do
     flag_comments
     |> Stream.map(fn("#," <> content) -> content end)
-    |> Stream.flat_map(&String.split(&1, ~r/\s+/, trim: true))
+    |> Stream.flat_map(&String.split(&1, ~r/[,\s]+/, trim: true))
     |> Enum.into(MapSet.new)
   end
 

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -178,15 +178,15 @@ defmodule Gettext.PO.ParserTest do
 
   test "flags are extracted in to the :flags field of a translation" do
     parsed = Parser.parse([
-      {:comment, 1, "#, flag other-flag"},
+      {:comment, 1, "#, flag,a-flag b-flag, c-flag"},
       {:comment, 2, "# comment"},
-      {:comment, 3, "#, other-flag other-other-flag"},
+      {:comment, 3, "#, flag,  ,d-flag ,, e-flag"},
       {:msgid, 4}, {:str, 4, "foo"},
       {:msgstr, 5}, {:str, 5, "bar"},
     ])
 
     assert {:ok, [], [], [%Translation{} = t]} = parsed
-    assert Enum.sort(t.flags) == ~w(flag other-flag other-other-flag)
+    assert Enum.sort(t.flags) == ~w(a-flag b-flag c-flag d-flag e-flag flag)
     assert t.comments == ["# comment"]
   end
 

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -300,7 +300,7 @@ defmodule Gettext.POTest do
   test "dump/1: flags" do
     po = %PO{translations: [
       %Translation{
-        flags: ~w(foo bar baz) |> Enum.into(MapSet.new),
+        flags: MapSet.new(~w(bar baz foo)),
         comments: ["# other comment"],
         msgid: ["foo"],
         msgstr: ["bar"]},
@@ -308,7 +308,7 @@ defmodule Gettext.POTest do
 
     assert IO.iodata_to_binary(PO.dump(po)) == ~S"""
     # other comment
-    #, bar baz foo
+    #, bar, baz, foo
     msgid "foo"
     msgstr "bar"
     """


### PR DESCRIPTION
GNU `msgmerge` separates flags by `", "`, do this on output as well,
but accept `[, ]+` as a separator on input.

When parsing multiple flags of a file generated by `msgmerge`, the separating `","` is currently parsed as being part of the preceding flag, which is obviously not what was intended by `msgmerge`.