### PR TITLE
fuzzy merge: an exact match should not prevent a later fuzzy match

### DIFF
--- a/lib/gettext/fuzzy.ex
+++ b/lib/gettext/fuzzy.ex
@@ -58,7 +58,7 @@ defmodule Gettext.Fuzzy do
   """
   @spec merge(PO.translation, PO.translation) :: PO.translation
   def merge(new, existing) do
-    new
+    %{ new | comments: existing.comments }
     |> merge_fuzzy(existing)
     |> PO.Translations.mark_as_fuzzy()
   end
@@ -67,6 +67,8 @@ defmodule Gettext.Fuzzy do
     do: %{new | msgstr: existing.msgstr}
   defp merge_fuzzy(%Translation{} = new, %PluralTranslation{} = existing),
     do: %{new | msgstr: existing.msgstr[0]}
+  defp merge_fuzzy(%PluralTranslation{msgstr: nil} = new, %Translation{} = existing),
+    do: %{new | msgstr: %{0 => existing.msgstr}}
   defp merge_fuzzy(%PluralTranslation{} = new, %Translation{} = existing),
     do: %{new | msgstr: Map.new(new.msgstr, fn {i, _} -> {i, existing.msgstr} end)}
   defp merge_fuzzy(%PluralTranslation{} = new, %PluralTranslation{} = existing),

--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Gettext.Merge do
 
       #, fuzzy
       msgid "hello, world!"
-      msgstr "ciao, mondo!"
+      msgstr "ciao, mondo"
 
   Generally, a `fuzzy` flag calls for review from a translator.
 


### PR DESCRIPTION
Merging the following new POT:
```po
msgid "Hello world!"
msgstr ""

msgid "Hello worlds!"
msgstr ""
```
into this PO:
```po
msgid "Hello world!"
msgstr "Hallo Welt!"
```
should result in:
```po
msgid "Hello world!"
msgstr "Hallo Welt!"

#, fuzzy
msgid "Hello worlds!"
msgstr "Hallo Welt!"
```
The branch also contains a few more bugfixes and test cases related to fuzzy matching and merging of fuzzy matches.