### PR TITLE
[WIP] Extracted comments

### DIFF
--- a/lib/gettext/extractor_agent.ex
+++ b/lib/gettext/extractor_agent.ex
@@ -67,6 +67,7 @@ defmodule Gettext.ExtractorAgent do
   end
 
   defp merge_translations(t1, t2) do
-    update_in t1.references, &(&1 ++ t2.references)
+    %{ t1 | references: t1.references ++ t2.references,
+       extracted_comments: t1.extracted_comments ++ t2.extracted_comments}
   end
 end

--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -55,8 +55,8 @@ defmodule Gettext.Merger do
       * existing msgstr are preserved (the ones in the POT file are empty anyways)
       * existing translator comments are preserved (there are no translator
         comments in POT files)
-      * existing references are discarded (as they're now outdated) and replaced
-        by the references in the POT file
+      * existing references and extracted comments are discarded (as they're now
+        outdated) and replaced by those in the POT file
 
   """
   @spec merge(PO.t, PO.t, Keyword.t) :: PO.t
@@ -122,7 +122,8 @@ defmodule Gettext.Merger do
     %Translation{
       msgid: new.msgid, # they are the same
       msgstr: old.msgstr, # new.msgstr should be empty since it's a POT file
-      comments: old.comments, # new has no translator comments
+      comments: old.comments, # new has no comments from translators
+      extracted_comments: new.extracted_comments, # new has new comments for translators
       references: new.references,
     }
   end
@@ -132,7 +133,8 @@ defmodule Gettext.Merger do
       msgid: new.msgid, # they are the same
       msgid_plural: new.msgid_plural, # they are the same
       msgstr: old.msgstr, # new.msgstr should be empty since it's a POT file
-      comments: old.comments, # new has no translator comments
+      comments: old.comments, # new has no comments from translators
+      extracted_comments: new.extracted_comments, # new has new comments for translators
       references: new.references,
     }
   end

--- a/lib/gettext/po.ex
+++ b/lib/gettext/po.ex
@@ -230,15 +230,18 @@ defmodule Gettext.PO do
 
   defp dump_translation(%Translation{} = t) do
     [dump_comments(t.comments),
-     dump_flags(t.flags), dump_references(t.references),
+     dump_comments(t.extracted_comments),
+     dump_references(t.references),
+     dump_flags(t.flags),
      dump_kw_and_strings("msgid", t.msgid),
      dump_kw_and_strings("msgstr", t.msgstr)]
   end
 
   defp dump_translation(%PluralTranslation{} = t) do
     [dump_comments(t.comments),
-     dump_flags(t.flags),
+     dump_comments(t.extracted_comments),
      dump_references(t.references),
+     dump_flags(t.flags),
      dump_kw_and_strings("msgid", t.msgid),
      dump_kw_and_strings("msgid_plural", t.msgid_plural),
      dump_plural_msgstr(t.msgstr)]

--- a/lib/gettext/po/parser.ex
+++ b/lib/gettext/po/parser.ex
@@ -32,12 +32,18 @@ defmodule Gettext.PO.Parser do
   end
 
   defp to_struct({:translation, translation}),
-    do: struct(Translation, translation) |> extract_references() |> extract_flags()
+    do: struct(Translation, translation) |> extract_extracted_comments() |> extract_references() |> extract_flags()
   defp to_struct({:plural_translation, translation}),
-    do: struct(PluralTranslation, translation) |> extract_references() |> extract_flags()
+    do: struct(PluralTranslation, translation) |> extract_extracted_comments() |> extract_references() |> extract_flags()
 
   defp parse_error({:error, {line, _module, reason}}) do
     {:error, line, parse_error_reason(reason)}
+  end
+
+  defp extract_extracted_comments(%{__struct__: _, comments: comments} = translation) do
+    {extracted_comments, other_comments} = Enum.partition(comments, &match?("#." <> _, &1))
+
+    %{translation | extracted_comments: extracted_comments, comments: other_comments}
   end
 
   defp extract_references(%{__struct__: _, comments: comments} = translation) do

--- a/lib/gettext/po/plural_translation.ex
+++ b/lib/gettext/po/plural_translation.ex
@@ -17,8 +17,10 @@ defmodule Gettext.PO.PluralTranslation do
     * `msgstr` - a map which maps plural forms as keys to translated strings as
       values. The plural forms mentioned here are the ones described in
       `Gettext.Plural`.
-    * `comments` - a list of comments as they are found in the PO file (e.g.,
+    * `comments` - a list of translator comments as they are found in the PO file (e.g.,
       `["# foo"]`).
+    * `extracted_comments`  - a list of comments extracted from the program source (e.g.,
+      `["#. bar"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
     * `flags` - a set of flags for this translation.
@@ -32,6 +34,7 @@ defmodule Gettext.PO.PluralTranslation do
     msgid_plural: [binary],
     msgstr: %{non_neg_integer => [binary]},
     comments: [binary],
+    extracted_comments: [binary],
     references: [{binary, pos_integer}],
     flags: MapSet.t,
     po_source_line: pos_integer,
@@ -41,6 +44,7 @@ defmodule Gettext.PO.PluralTranslation do
             msgid_plural: nil,
             msgstr: nil,
             comments: [],
+            extracted_comments: [],
             references: [],
             flags: MapSet.new,
             po_source_line: nil

--- a/lib/gettext/po/translation.ex
+++ b/lib/gettext/po/translation.ex
@@ -16,8 +16,10 @@ defmodule Gettext.PO.Translation do
 
     * `msgid` - the id of the translation.
     * `msgstr` - the translated string.
-    * `comments` - a list of comments as they are found in the PO file (e.g.,
+    * `comments` - a list of translator comments as they are found in the PO file (e.g.,
       `["# foo"]`).
+    * `extracted_comments`  - a list of comments extracted from the program source (e.g.,
+      `["#. bar"]`).
     * `references` - a list of references (files this translation comes from) in
       the form `{file, line}`.
     * `flags` - a set of flags for this translation.
@@ -30,6 +32,7 @@ defmodule Gettext.PO.Translation do
     msgid: [binary],
     msgstr: [binary],
     comments: [binary],
+    extracted_comments: [binary],
     references: [{binary, pos_integer}],
     flags: MapSet.t,
     po_source_line: pos_integer,
@@ -38,6 +41,7 @@ defmodule Gettext.PO.Translation do
   defstruct msgid: nil,
             msgstr: nil,
             comments: [],
+            extracted_comments: [],
             references: [],
             flags: MapSet.new,
             po_source_line: nil

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -179,7 +179,7 @@ defmodule Gettext.ExtractorTest do
       def bar do
         gettext "foo"
         dngettext "errors", "one error", "%{count} errors", 2
-        gettext "foo"
+        gettext "foo", %{comment: "blarg\\nblub"}
         Gettext.ExtractorTest.MyOtherGettext.dgettext "greetings", "hi"
       end
     end
@@ -193,6 +193,8 @@ defmodule Gettext.ExtractorTest do
         msgid ""
         msgstr ""
 
+        #. blarg
+        #. blub
         #: foo.ex:14 foo.ex:16
         msgid "foo"
         msgstr ""

--- a/test/gettext/merger_test.exs
+++ b/test/gettext/merger_test.exs
@@ -52,6 +52,14 @@ defmodule Gettext.MergerTest do
     assert t.comments == ["# existing comment"]
   end
 
+  test "merge/2: when translations match, new extracted comments replace old ones" do
+    old_po = %PO{translations: [%Translation{msgid: ["foo"], extracted_comments: ["#. existing extracted comment"]}]}
+    new_pot = %PO{translations: [%Translation{msgid: ["foo"], extracted_comments: ["#. new extracted comment"]}]}
+
+    assert %PO{translations: [t]} = Merger.merge(old_po, new_pot, @opts)
+    assert t.extracted_comments == ["#. new extracted comment"]
+  end
+
   test "merge/2: when translations match, existing references are replaced by new ones" do
     old_po = %PO{translations: [%Translation{msgid: "foo", references: [{"foo.ex", 1}]}]}
     new_pot = %PO{translations: [%Translation{msgid: "foo", references: [{"bar.ex", 1}]}]}

--- a/test/gettext/po/parser_test.exs
+++ b/test/gettext/po/parser_test.exs
@@ -71,10 +71,11 @@ defmodule Gettext.PO.ParserTest do
   test "comments are associated with translations" do
     parsed = Parser.parse([
       {:comment, 1, "# This is a translation"},
-      {:comment, 2, "#: lib/foo.ex:32"},
-      {:comment, 3, "# Ah, another comment!"},
-      {:msgid, 4}, {:str, 4, "foo"},
-      {:msgstr, 5}, {:str, 5, "bar"},
+      {:comment, 2, "#. Note to translators"},
+      {:comment, 3, "#: lib/foo.ex:32"},
+      {:comment, 4, "# Ah, another comment!"},
+      {:msgid, 5}, {:str, 5, "foo"},
+      {:msgstr, 6}, {:str, 6, "bar"},
     ])
 
     assert {:ok, [], [], [%Translation{
@@ -84,6 +85,7 @@ defmodule Gettext.PO.ParserTest do
         "# This is a translation",
         "# Ah, another comment!",
       ],
+      extracted_comments: ["#. Note to translators"],
       references: [{"lib/foo.ex", 32}],
     }]} = parsed
   end

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -250,6 +250,23 @@ defmodule Gettext.POTest do
     """
   end
 
+  test "dump/1: translation with extracted comments" do
+    po = %PO{headers: [], translations: [
+      %Translation{
+        msgid: ["foo"],
+        msgstr: ["bar"],
+        extracted_comments: ["#. extracted comment", "#. another extracted comment"],
+      }
+    ]}
+
+    assert IO.iodata_to_binary(PO.dump(po)) == ~S"""
+    #. extracted comment
+    #. another extracted comment
+    msgid "foo"
+    msgstr "bar"
+    """
+  end
+
   test "dump/1: references" do
     po = %PO{translations: [
       %Translation{


### PR DESCRIPTION
The GNU gettext suite can extract some specially marked comments from the program's source to be included into `.pot` and `.po` files as comments *to* the translators. This has proven to be very valuable in past projects.
This branch currently contains two commits, one introducing handling, parsing, and dumping of extracted comments from/to `.po` files and a second commit implementing the extraction itself. I don't really like the way I've implemented the actual extraction process and would like some feedback how to improve it.
Currently, source like this:
```ex
def cocoballs(n) do
  gettext "Cocoballs are delicious!",
    %{comment: "These are Guyanese Cocoa balls, made of raw cocoa to be used when making *real* hot chocolate."}
```
will result in a `.pot` like:
```po
#. These are Guyanese Cocoa balls, made of raw cocoa to be used when making *real* hot chocolate.
msgid "Cocoballs are delicious!"
msgstr ""
```
Do not confuse extracted comments with comments *from* translators, which are marked like:
```po
# How big are these? Depending on size they could be "Bälle" or "Kugeln"
msgid "Cocoballs are delicious!"
msgstr "Kakaokugeln sind lecker!"
```