### PR TITLE
Define intermediate functions per locale + domain and support parallel compilation

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -439,6 +439,11 @@ defmodule Gettext do
     * `:default_locale` - a string which specifies the default locale to use for
       the given backend.
 
+    * `:one_module_per_locale` - instead of bundling all locales into a single
+      module, this option makes Gettext build one internal module per locale.
+      This reduces compilation times and beam file sizes for large projects.
+      This option requires Elixir v1.6.
+
   ### Mix tasks configuration
 
   You can configure Gettext Mix tasks under the `:gettext` key in the


### PR DESCRIPTION
This speeds up compilation time about roughly 20% in large gettext backends.

On the sample project we had, the original time compilation time of the backend was 30s, which falls down to 24s with the first commit.

By using the option in the second commit, compilation time drops to 11s (my machine has 2 cores, the more than 2x increase is probably thanks to the smaller beam files).