### PR TITLE
Add option domain_prefix for backends

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -505,12 +505,16 @@ defmodule Gettext do
   @type backend :: module
   @type bindings :: %{} | Keyword.t
 
+  @default_domain "default"
+
   @doc false
   defmacro __using__(opts) do
     quote do
       require Logger
 
       @gettext_opts unquote(opts)
+      @default_domain "default"
+
       @before_compile Gettext.Compiler
 
       def handle_missing_bindings(exception, incomplete) do
@@ -677,7 +681,7 @@ defmodule Gettext do
   """
   @spec gettext(module, binary, bindings) :: binary
   def gettext(backend, msgid, bindings \\ %{}) do
-    dgettext(backend, "default", msgid, bindings)
+    dgettext(backend, @default_domain, msgid, bindings)
   end
 
   @doc """
@@ -732,7 +736,7 @@ defmodule Gettext do
   """
   @spec ngettext(module, binary, binary, non_neg_integer, bindings) :: binary
   def ngettext(backend, msgid, msgid_plural, n, bindings \\ %{}) do
-    dngettext(backend, "default", msgid, msgid_plural, n, bindings)
+    dngettext(backend, @default_domain, msgid, msgid_plural, n, bindings)
   end
 
   @doc """

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -515,6 +515,8 @@ defmodule Gettext do
       @gettext_opts unquote(opts)
       @default_domain "default"
 
+      def domain_prefix, do: unquote(opts[:domain_prefix] || "")
+
       @before_compile Gettext.Compiler
 
       def handle_missing_bindings(exception, incomplete) do
@@ -667,6 +669,7 @@ defmodule Gettext do
   def dgettext(backend, domain, msgid, bindings)
       when is_atom(backend) and is_binary(domain) and is_binary(msgid) and is_map(bindings) do
     locale = get_locale(backend)
+    domain = "#{backend.domain_prefix()}#{domain}"
     result = backend.lgettext(locale, domain, msgid, bindings)
     handle_backend_result(result, backend, locale, domain, msgid)
   end
@@ -721,6 +724,7 @@ defmodule Gettext do
            is_binary(msgid_plural) and is_integer(n) and n >= 0 and
            is_map(bindings) do
     locale = get_locale(backend)
+    domain = "#{backend.domain_prefix()}#{domain}"
     result = backend.lngettext(locale, domain, msgid, msgid_plural, n, bindings)
     handle_backend_result(result, backend, locale, domain, msgid)
   end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -244,6 +244,24 @@ defmodule Gettext do
 
   When `gettext` or `ngettext` are used, the `"default"` domain is used.
 
+  ### Domain prefix
+
+  You can specify domain prefix for your module, for example:
+
+      defmodule MyApp.Gettext do
+        use Gettext, otp_app: :my_app, domain_prefix: "admin."
+      end
+
+  Then all translations will be taken from files with prefix `adimin.`:
+
+      MyApp.Gettext.gettext "Hello admin"
+      #=> "Hello admin"
+      # from it/LC_MESSAGES/admin.default.po
+
+      MyApp.Gettext.dgettext "errors", "Error!"
+      #=> "Error!"
+      # from it/LC_MESSAGES/admin.errors.po
+
   ## Interpolation
 
   All `*gettext` functions and macros provided by gettext support interpolation.

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -80,7 +80,7 @@ defmodule Gettext.Compiler do
 
       defmacro gettext_noop(msgid) do
         quote do
-          unquote(__MODULE__).dgettext_noop("default", unquote(msgid))
+          unquote(__MODULE__).dgettext_noop(unquote(@default_domain), unquote(msgid))
         end
       end
 
@@ -98,7 +98,7 @@ defmodule Gettext.Compiler do
 
       defmacro ngettext_noop(msgid, msgid_plural) do
         quote do
-          unquote(__MODULE__).dngettext_noop("default", unquote(msgid), unquote(msgid_plural))
+          unquote(__MODULE__).dngettext_noop(unquote(@default_domain), unquote(msgid), unquote(msgid_plural))
         end
       end
 
@@ -111,7 +111,7 @@ defmodule Gettext.Compiler do
 
       defmacro gettext(msgid, bindings \\ Macro.escape(%{})) do
         quote do
-          unquote(__MODULE__).dgettext("default", unquote(msgid), unquote(bindings))
+          unquote(__MODULE__).dgettext(unquote(@default_domain), unquote(msgid), unquote(bindings))
         end
       end
 
@@ -134,7 +134,7 @@ defmodule Gettext.Compiler do
       defmacro ngettext(msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
         quote do
           unquote(__MODULE__).dngettext(
-            "default",
+            unquote(@default_domain),
             unquote(msgid),
             unquote(msgid_plural),
             unquote(n),

--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -56,6 +56,7 @@ defmodule Gettext.Extractor do
   """
   @spec extract(Macro.Env.t, module, binary, binary | {binary, binary}, [binary]) :: :ok
   def extract(%Macro.Env{file: file, line: line} = _caller, backend, domain, id, extracted_comments) do
+    domain = "#{backend.domain_prefix()}#{domain}"
     ExtractorAgent.add_translation(backend, domain, create_translation_struct(id, file, line, extracted_comments))
   end
 

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/prefix.default.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/prefix.default.po
@@ -1,0 +1,10 @@
+msgid "Hello world!"
+msgstr "Ciao mondo!"
+
+msgid "Hello %{name}!"
+msgstr "Ciao %{name}!"
+
+msgid "One new email!"
+msgid_plural "%{count} new emails!"
+msgstr[0] "Una nuova email!"
+msgstr[1] "%{count} nuove email!"

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/prefix.errors.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/prefix.errors.po
@@ -1,0 +1,7 @@
+msgid "Invalid email address!"
+msgstr "Indirizzo email non valido!"
+
+msgid "There was an error!"
+msgid_plural "There were %{count} errors!"
+msgstr[0] "C'è stato un errore!"
+msgstr[1] "Ci sono stati %{count} errori!"

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -186,6 +186,21 @@ defmodule Gettext.ExtractorTest do
         Gettext.ExtractorTest.MyOtherGettext.dgettext "greetings", "hi"
       end
     end
+
+    defmodule Gettext.ExtractorTest.MyAdminGettext do
+      use Gettext, otp_app: :test_application, domain_prefix: "admin."
+    end
+
+    defmodule Foo.Admin do
+      import Gettext.ExtractorTest.MyAdminGettext
+
+      def bar do
+        gettext "User"
+        ngettext "user", "%{count} users", 2
+        dgettext "errors", "Error occured"
+        dngettext "errors", "one error", "%{count} errors", 2
+      end
+    end
     """
 
     Code.compile_string(code, Path.join(File.cwd!, "foo.ex"))
@@ -226,6 +241,42 @@ defmodule Gettext.ExtractorTest do
           #, elixir-format
           #: foo.ex:20
           msgid "hi"
+          msgstr ""
+          """},
+
+      {"priv/gettext/admin.default.pot",
+          ~S"""
+          msgid ""
+          msgstr ""
+
+          #, elixir-format
+          #: foo.ex:33
+          msgid "user"
+          msgid_plural "%{count} users"
+          msgstr[0] ""
+          msgstr[1] ""
+
+          #, elixir-format
+          #: foo.ex:32
+          msgid "User"
+          msgstr ""
+          """},
+
+      {"priv/gettext/admin.errors.pot",
+          ~S"""
+          msgid ""
+          msgstr ""
+
+          #, elixir-format
+          #: foo.ex:35
+          msgid "one error"
+          msgid_plural "%{count} errors"
+          msgstr[0] ""
+          msgstr[1] ""
+
+          #, elixir-format
+          #: foo.ex:34
+          msgid "Error occured"
           msgstr ""
           """}
     ]

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -19,6 +19,10 @@ defmodule GettextTest.TranslatorWithCustomPluralForms do
   use Gettext, otp_app: :test_application, plural_forms: Plural
 end
 
+defmodule GettextTest.TranslatorWithDomainPrefix do
+  use Gettext, otp_app: :test_application, domain_prefix: "prefix."
+end
+
 defmodule GettextTest do
   use ExUnit.Case
 
@@ -27,8 +31,10 @@ defmodule GettextTest do
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
   alias GettextTest.TranslatorWithCustomPluralForms
+  alias GettextTest.TranslatorWithDomainPrefix
   require Translator
   require TranslatorWithCustomPriv
+  require TranslatorWithDomainPrefix
 
   test "the default locale is \"en\"" do
     assert Gettext.get_locale() == "en"
@@ -499,5 +505,39 @@ defmodule GettextTest do
       assert lgettext("pt_BR", "nonexistent", "Hello world", %{}) ==
              {:default, "Hello world"}
     end
+  end
+
+  test "using domain prefix with macroses" do
+    alias TranslatorWithDomainPrefix, as: T
+
+    Gettext.put_locale T, "it"
+
+    assert T.gettext("Hello world!") == "Ciao mondo!"
+    assert T.gettext("Hello %{name}!", %{name: "Jane"}) == "Ciao Jane!"
+
+    assert T.ngettext("One new email!", "%{count} new emails!", 1) == "Una nuova email!"
+    assert T.ngettext("One new email!", "%{count} new emails!", 2) == "2 nuove email!"
+
+    assert T.dgettext("errors", "Invalid email address!") == "Indirizzo email non valido!"
+
+    assert T.dngettext("errors", "There was an error!", "There were %{count} errors!", 1) == "C'è stato un errore!"
+    assert T.dngettext("errors", "There was an error!", "There were %{count} errors!", 2) == "Ci sono stati 2 errori!"
+  end
+
+  test "using domain prefix with module functions" do
+    alias TranslatorWithDomainPrefix, as: T
+
+    Gettext.put_locale T, "it"
+
+    assert Gettext.gettext(T, "Hello world!") == "Ciao mondo!"
+    assert Gettext.gettext(T, "Hello %{name}!", %{name: "Jane"}) == "Ciao Jane!"
+
+    assert Gettext.ngettext(T, "One new email!", "%{count} new emails!", 1) == "Una nuova email!"
+    assert Gettext.ngettext(T, "One new email!", "%{count} new emails!", 2) == "2 nuove email!"
+
+    assert Gettext.dgettext(T, "errors", "Invalid email address!") == "Indirizzo email non valido!"
+
+    assert Gettext.dngettext(T, "errors", "There was an error!", "There were %{count} errors!", 1) == "C'è stato un errore!"
+    assert Gettext.dngettext(T, "errors", "There was an error!", "There were %{count} errors!", 2) == "Ci sono stati 2 errori!"
   end
 end


### PR DESCRIPTION
Added option `domain_prefix` for backends, to remove duplication in `dgettext`.

Before:

```elixir
defmodule Admin.Gettext do
  use Gettext, otp_app: :my_app
end

Admin.Gettext.dgettext("admin.default", "Page title")

Admin.Gettext.dgettext("admin.articles", "Title")

Admin.Gettext.dgettext("admin.errors", "Email is invalid")
```

After:

```elixir
defmodule Admin.Gettext do
  use Gettext, otp_app: :my_app, domain_prefix: "admin."
end

Admin.Gettext.gettext("Page title")

Admin.Gettext.dgettext("articles", "Title")

Admin.Gettext.dgettext("errors", "Email is invalid")
```