### PR TITLE
Implement tag bindings

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -527,6 +527,9 @@ defmodule Gettext.Compiler do
       key, acc when is_atom(key) ->
         quote do: unquote(acc) <> to_string(unquote(Macro.var(key, __MODULE__)))
 
+      {key, inner}, acc when is_atom(key) ->
+        quote do: unquote(acc) <> to_string(unquote(Macro.var(key, __MODULE__)).(unquote(inner)))
+
       str, acc ->
         quote do: unquote(acc) <> unquote(str)
     end)

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
@@ -4,6 +4,14 @@ msgstr "Ciao %{name}"
 msgid "My name is %{name} and I'm %{age}"
 msgstr "Mi chiamo %{name} e ho %{age} anni"
 
+msgid "I lived in %{wiki:Italy} for a year"
+msgstr "Ho vissuto in %{wiki:italia} per un anno"
+
+msgid "I lived in %{wiki:Italy} for one year"
+msgid_plural "I lived in %{wiki:Italy} for %{count} years"
+msgstr[0] "Ho vissuto in %{wiki:italia} per un anno"
+msgstr[1] "Ho vissuto in %{wiki:italia} per %{count} anni"
+
 msgid "You have one message, %{name}"
 msgid_plural "You have %{count} messages, %{name}"
 msgstr[0] "Hai un messaggio, %{name}"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -205,6 +205,13 @@ defmodule GettextTest do
     # A map of bindings is supported as well.
     assert Translator.lgettext("it", "interpolations", "Hello %{name}", %{name: "Jane"}) ==
              {:ok, "Ciao Jane"}
+
+    # Tag bindings 
+    msgid = "I lived in %{wiki:Italy} for a year"
+    wiki = &~s[<a href="#italy">#{&1}<a>]
+
+    assert Translator.lgettext("it", "interpolations", msgid, %{wiki: wiki}) ==
+             {:ok, ~s[Ho vissuto in <a href="#italy">italia<a> per un anno]}
   end
 
   test "interpolation is supported by lngettext" do
@@ -225,6 +232,17 @@ defmodule GettextTest do
 
     assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 0, %{name: "Jane"}) ==
              {:ok, "Hai 0 messaggi, Jane"}
+
+    # Tag bindings 
+    msgid = "I lived in %{wiki:Italy} for one year"
+    msgid_plural = "I lived in %{wiki:Italy} for %{count} years"
+    wiki = &~s[<a href="#italy">#{&1}<a>]
+
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 1, %{wiki: wiki}) ==
+             {:ok, ~s[Ho vissuto in <a href="#italy">italia<a> per un anno]}
+
+    assert Translator.lngettext("it", "interpolations", msgid, msgid_plural, 2, %{wiki: wiki}) ==
+             {:ok, ~s[Ho vissuto in <a href="#italy">italia<a> per 2 anni]}
   end
 
   test "strings are concatenated before generating function clauses" do


### PR DESCRIPTION
This allows bindings to be 1-arity functions receiving the translated text of `%{binding:translatable content}`. This would make it possible to have e.g. links being assembled around some word within a sentence without the need to break the sentence up into multiple parts, which would need to be individually assembled or directly embedding html in the translatable content.

```
# Tag bindings 
msgid = "I lived in %{wiki:Italy} for a year"
wiki = &(~s[<a href="https://en.wikipedia.org/wiki/Italy">#{&1}<a>])

assert Translator.lgettext("it", "interpolations", msgid, %{wiki: wiki}) ==
         {:ok, ~s[Ho vissuto in <a href="https://en.wikipedia.org/wiki/Italy">italia<a> per un anno]}
```

Things still to be done:

* [ ] Handling the new error case in `gettext.ex`
* [ ] Update docs