### PR TITLE
Fix bindings type.

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -512,7 +512,7 @@ defmodule Gettext do
 
   @type locale :: binary
   @type backend :: module
-  @type bindings :: %{} | Keyword.t()
+  @type bindings :: map() | Keyword.t()
 
   @doc false
   defmacro __using__(opts) do


### PR DESCRIPTION
%{} is the type for an empty map, we should use map() instead.