### PR TITLE
Add handle_missing_translation/4,6 callbacks to Gettext backends

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -528,6 +528,28 @@ defmodule Gettext do
       end
 
       defoverridable handle_missing_bindings: 2
+
+      def handle_missing_translation(_locale, domain, msgid, bindings) do
+        import Gettext.Interpolation, only: [to_interpolatable: 1, interpolate: 2]
+
+        Gettext.Compiler.warn_if_domain_contains_slashes(domain)
+
+        with {:ok, interpolated} <- interpolate(to_interpolatable(msgid), bindings),
+             do: {:default, interpolated}
+      end
+
+      def handle_missing_translation(_locale, domain, msgid, msgid_plural, n, bindings) do
+        import Gettext.Interpolation, only: [to_interpolatable: 1, interpolate: 2]
+
+        Gettext.Compiler.warn_if_domain_contains_slashes(domain)
+        string = if n == 1, do: msgid, else: msgid_plural
+        bindings = Map.put(bindings, :count, n)
+
+        with {:ok, interpolated} <- interpolate(to_interpolatable(string), bindings),
+             do: {:default, interpolated}
+      end
+
+      defoverridable handle_missing_translation: 4, handle_missing_translation: 6
     end
   end
 

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -538,7 +538,7 @@ defmodule Gettext do
              do: {:default, interpolated}
       end
 
-      def handle_missing_translation(_locale, domain, msgid, msgid_plural, n, bindings) do
+      def handle_missing_plural_translation(_locale, domain, msgid, msgid_plural, n, bindings) do
         import Gettext.Interpolation, only: [to_interpolatable: 1, interpolate: 2]
 
         Gettext.Compiler.warn_if_domain_contains_slashes(domain)
@@ -549,7 +549,7 @@ defmodule Gettext do
              do: {:default, interpolated}
       end
 
-      defoverridable handle_missing_translation: 4, handle_missing_translation: 6
+      defoverridable handle_missing_translation: 4, handle_missing_plural_translation: 6
     end
   end
 

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -52,6 +52,38 @@ defmodule Gettext.Backend do
               binary | no_return
 
   @doc """
+  Default handling for translations with a missing translation.
+
+  When a Gettext function/macro is called with a string to translate into a locale but that
+  locale doesn't provide a translation for that string, this callback is invoked. `msgid` is the
+  string that Gettext tried to translate.
+
+  This function should return `{:ok, translated}` if a translation can be fetched or constructed
+  for the given string, or `{:default, msgid}` otherwise.
+  """
+  @callback handle_missing_translation(
+              Gettext.locale(),
+              domain :: String.t(),
+              msgid :: String.t(),
+              bindings :: map()
+            ) :: {:ok | :default, String.t()}
+
+  @doc """
+  Default handling for plural translations with a missing translation.
+
+  Same as `c:handle_missing_translation/4`, but for plural translations. In this case, `n` is
+  the number used for pluralizing the translated string.
+  """
+  @callback handle_missing_translation(
+              Gettext.locale(),
+              domain :: String.t(),
+              msgid :: String.t(),
+              msgid_plural :: String.t(),
+              n :: non_neg_integer(),
+              bindings :: map()
+            ) :: {:ok | :default, String.t()}
+
+  @doc """
   Translates the given `msgid` in the given `domain`.
 
   `bindings` is a map of bindings to support interpolation.

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -74,7 +74,7 @@ defmodule Gettext.Backend do
   Same as `c:handle_missing_translation/4`, but for plural translations. In this case, `n` is
   the number used for pluralizing the translated string.
   """
-  @callback handle_missing_translation(
+  @callback handle_missing_plural_translation(
               Gettext.locale(),
               domain :: String.t(),
               msgid :: String.t(),

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -66,7 +66,7 @@ defmodule Gettext.Compiler do
         do: handle_missing_translation(locale, domain, msgid, bindings)
 
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings),
-        do: handle_missing_translation(locale, domain, msgid, msgid_plural, n, bindings)
+        do: handle_missing_plural_translation(locale, domain, msgid, msgid_plural, n, bindings)
     end
   end
 
@@ -338,7 +338,7 @@ defmodule Gettext.Compiler do
         end
 
         Kernel.unquote(kind)(unquote(plural_fun)(msgid, msgid_plural, n, bindings)) do
-          unquote(env.module).handle_missing_translation(
+          unquote(env.module).handle_missing_plural_translation(
             unquote(locale),
             unquote(domain),
             msgid,

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -60,8 +60,13 @@ defmodule Gettext.Compiler do
       def lngettext(locale, domain, msgid, msgid_plural, n, bindings)
 
       unquote(compile_po_files(env, translations_dir, opts))
-      unquote(catch_all_clauses())
-      unquote(catch_all_helpers())
+
+      # Catch-all clauses.
+      def lgettext(locale, domain, msgid, bindings),
+        do: handle_missing_translation(locale, domain, msgid, bindings)
+
+      def lngettext(locale, domain, msgid, msgid_plural, n, bindings),
+        do: handle_missing_translation(locale, domain, msgid, msgid_plural, n, bindings)
     end
   end
 
@@ -170,53 +175,6 @@ defmodule Gettext.Compiler do
   end
 
   @doc """
-  Returns the quoted code for the dynamic clauses of `lgettext/4` and
-  `lngettext/6`.
-  """
-  @spec catch_all_clauses() :: Macro.t()
-  def catch_all_clauses() do
-    quote do
-      def lgettext(_locale, domain, msgid, bindings) do
-        catch_all(domain, msgid, bindings)
-      end
-
-      def lngettext(_locale, domain, msgid, msgid_plural, n, bindings) do
-        catch_all_n(domain, msgid, msgid_plural, n, bindings)
-      end
-    end
-  end
-
-  @doc """
-  Defines helper functions for handling catch all throughout the backend.
-  """
-  @spec catch_all_helpers() :: Macro.t()
-  def catch_all_helpers() do
-    quote do
-      defp catch_all(domain, msgid, bindings) do
-        import Gettext.Interpolation, only: [to_interpolatable: 1, interpolate: 2]
-
-        Gettext.Compiler.warn_if_domain_contains_slashes(domain)
-
-        with {:ok, interpolated} <- interpolate(to_interpolatable(msgid), bindings) do
-          {:default, interpolated}
-        end
-      end
-
-      defp catch_all_n(domain, msgid, msgid_plural, n, bindings) do
-        import Gettext.Interpolation, only: [to_interpolatable: 1, interpolate: 2]
-
-        Gettext.Compiler.warn_if_domain_contains_slashes(domain)
-        string = if n == 1, do: msgid, else: msgid_plural
-        bindings = Map.put(bindings, :count, n)
-
-        with {:ok, interpolated} <- interpolate(to_interpolatable(string), bindings) do
-          {:default, interpolated}
-        end
-      end
-    end
-  end
-
-  @doc """
   Expands the given `msgid` in the given `env`, raising if it doesn't expand to
   a binary.
   """
@@ -285,18 +243,15 @@ defmodule Gettext.Compiler do
   @spec warn_if_domain_contains_slashes(binary) :: :ok
   def warn_if_domain_contains_slashes(domain) do
     if String.contains?(domain, "/") do
-      Logger.error(["Slashes in domains are not supported: ", inspect(domain)])
+      Logger.error(fn -> ["Slashes in domains are not supported: ", inspect(domain)] end)
     end
 
     :ok
   end
 
-  @doc """
-  Compiles all the `.po` files in the given directory (`dir`) into `lgettext/4`
-  and `lngettext/6` function clauses.
-  """
-  @spec compile_po_files(Macro.Env.t(), Path.t(), Keyword.t()) :: Macro.t()
-  def compile_po_files(env, dir, opts) do
+  # Compiles all the `.po` files in the given directory (`dir`) into `lgettext/4`
+  # and `lngettext/6` function clauses.
+  defp compile_po_files(env, dir, opts) do
     plural_mod = Keyword.get(opts, :plural_forms, Gettext.Plural)
     po_files = po_files_in_dir(dir)
 
@@ -310,18 +265,19 @@ defmodule Gettext.Compiler do
 
       quoted
     else
-      Enum.map(po_files, &compile_serial_po_file(&1, plural_mod))
+      Enum.map(po_files, &compile_serial_po_file(env, &1, plural_mod))
     end
   end
 
   defp create_locale_module(env, {module, translations}) do
-    exprs = [quote(do: @moduledoc(false)), catch_all_helpers() | translations]
+    exprs = [quote(do: @moduledoc(false)) | translations]
     Module.create(module, block(exprs), env)
     :ok
   end
 
-  defp compile_serial_po_file(path, plural_mod) do
-    {locale, domain, singular_fun, plural_fun, quoted} = compile_po_file(:defp, path, plural_mod)
+  defp compile_serial_po_file(env, path, plural_mod) do
+    {locale, domain, singular_fun, plural_fun, quoted} =
+      compile_po_file(:defp, path, env, plural_mod)
 
     quote do
       unquote(quoted)
@@ -338,7 +294,7 @@ defmodule Gettext.Compiler do
 
   defp compile_parallel_po_file(env, path, locales, plural_mod) do
     {locale, domain, singular_fun, plural_fun, locale_module_quoted} =
-      compile_po_file(:def, path, plural_mod)
+      compile_po_file(:def, path, env, plural_mod)
 
     module = :"#{env.module}.T_#{locale}"
 
@@ -359,7 +315,7 @@ defmodule Gettext.Compiler do
 
   # Compiles a .po file into a list of lgettext/4 (for translations) and
   # lngettext/6 (for plural translations) clauses.
-  defp compile_po_file(kind, path, plural_mod) do
+  defp compile_po_file(kind, path, env, plural_mod) do
     {locale, domain} = locale_and_domain_from_path(path)
     %PO{translations: translations, file: file} = PO.parse_file!(path)
 
@@ -373,11 +329,23 @@ defmodule Gettext.Compiler do
         unquote(translations)
 
         Kernel.unquote(kind)(unquote(singular_fun)(msgid, bindings)) do
-          catch_all(unquote(domain), msgid, bindings)
+          unquote(env.module).handle_missing_translation(
+            unquote(locale),
+            unquote(domain),
+            msgid,
+            bindings
+          )
         end
 
         Kernel.unquote(kind)(unquote(plural_fun)(msgid, msgid_plural, n, bindings)) do
-          catch_all_n(unquote(domain), msgid, msgid_plural, n, bindings)
+          unquote(env.module).handle_missing_translation(
+            unquote(locale),
+            unquote(domain),
+            msgid,
+            msgid_plural,
+            n,
+            bindings
+          )
         end
       end
 

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -19,6 +19,20 @@ defmodule GettextTest.TranslatorWithCustomPluralForms do
   use Gettext, otp_app: :test_application, plural_forms: Plural
 end
 
+defmodule GettextTest.HandleMissingTranslation do
+  use Gettext, otp_app: :test_application
+
+  def handle_missing_translation(locale, domain, msgid, bindings) do
+    send(self(), {locale, domain, msgid, bindings})
+    super(locale, domain, msgid, bindings)
+  end
+
+  def handle_missing_translation(locale, domain, msgid, msgid_plural, n, bindings) do
+    send(self(), {locale, domain, msgid, msgid_plural, n, bindings})
+    super(locale, domain, msgid, msgid_plural, n, bindings)
+  end
+end
+
 defmodule GettextTest do
   use ExUnit.Case
 
@@ -27,6 +41,8 @@ defmodule GettextTest do
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
   alias GettextTest.TranslatorWithCustomPluralForms
+  alias GettextTest.HandleMissingTranslation
+
   require Translator
   require TranslatorWithCustomPriv
 
@@ -260,6 +276,16 @@ defmodule GettextTest do
              {:missing_bindings, "Hello %{name}", [:name]}
   end
 
+  test "lgettext/4: fallbacks to handle_missing_translation if no translation is found" do
+    msgid = "Hello %{name}"
+    bindings = %{name: "Jane"}
+
+    assert HandleMissingTranslation.lgettext("pl", "foo", msgid, bindings) ==
+             {:default, "Hello Jane"}
+
+    assert_receive {"pl", "foo", ^msgid, ^bindings}
+  end
+
   test "lngettext/6: default handle_missing_binding preserves key" do
     msgid = "You have one message, %{name}"
     msgid_plural = "You have %{count} messages, %{name}"
@@ -280,6 +306,17 @@ defmodule GettextTest do
 
     assert Translator.lngettext("pl", "foo", msgid, msgid_plural, 9, %{}) ==
              {:default, "9 errors"}
+  end
+
+  test "lngettext/6: fallbacks to handle_missing_translation if no translation is found" do
+    msgid = "Hello %{name}"
+    msgid_plural = "Hello %{name}"
+    bindings = %{name: "Jane"}
+
+    assert HandleMissingTranslation.lngettext("pl", "foo", msgid, msgid_plural, 4, bindings) ==
+             {:default, "Hello Jane"}
+
+    assert_receive {"pl", "foo", ^msgid, ^msgid_plural, 4, ^bindings}
   end
 
   test "dgettext/3: binary msgid at compile-time" do

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -27,7 +27,7 @@ defmodule GettextTest.HandleMissingTranslation do
     super(locale, domain, msgid, bindings)
   end
 
-  def handle_missing_translation(locale, domain, msgid, msgid_plural, n, bindings) do
+  def handle_missing_plural_translation(locale, domain, msgid, msgid_plural, n, bindings) do
     send(self(), {locale, domain, msgid, msgid_plural, n, bindings})
     super(locale, domain, msgid, msgid_plural, n, bindings)
   end
@@ -308,7 +308,7 @@ defmodule GettextTest do
              {:default, "9 errors"}
   end
 
-  test "lngettext/6: fallbacks to handle_missing_translation if no translation is found" do
+  test "lngettext/6: fallbacks to handle_missing_plural_translation if no translation is found" do
     msgid = "Hello %{name}"
     msgid_plural = "Hello %{name}"
     bindings = %{name: "Jane"}


### PR DESCRIPTION
I went with two callbacks, `handle_missing_translation/4` for translations and `handle_missing_translation/6` for plural translations. I don't think that the approach with the exception, similar to `handle_missing_bindings/2`, worked very well in this case. We don't warn or don't produce an error message by default when a translation is missing, so the exception would feel a bit forced.

@josevalim a point one could make is that a user might want to actually raise on every missing translation, and in that case having a single exception (in a single callback, not two) that they can just raise might be beneficial. If you still think that's the better approach, it'll be an easy change to this PR :).