### PR TITLE
Allow for duplicates with msgctxt

### DIFF
--- a/lib/gettext/po/translations.ex
+++ b/lib/gettext/po/translations.ex
@@ -89,27 +89,24 @@ defmodule Gettext.PO.Translations do
 
       iex> t = %Gettext.PO.Translation{msgid: "foo"}
       iex> Gettext.PO.Translations.key(t)
-      "foo"
+      {nil, "foo"}
 
       iex> t = %Gettext.PO.PluralTranslation{msgid: "foo", msgid_plural: "foos"}
       iex> Gettext.PO.Translations.key(t)
-      {"foo", "foos"}
+      {nil, {"foo", "foos"}}
 
       iex> t = %Gettext.PO.PluralTranslation{msgctxt: "bar", msgid: "foo", msgid_plural: "foos"}
       iex> Gettext.PO.Translations.key(t)
       {"bar", {"foo", "foos"}}
   """
-  @spec key(PO.translation()) :: binary | {binary, binary} | {binary, {binary, binary}}
-  def key(%Translation{msgid: msgid, msgctxt: nil}), do: IO.iodata_to_binary(msgid)
+  @spec key(PO.translation()) :: {binary | nil, binary | {binary, binary}}
+  def key(%{msgctxt: msgctxt} = translation), do: {IO.iodata_to_binary(msgctxt), id_key(translation)}
 
-  def key(%Translation{msgctxt: msgctxt} = translation),
-    do: {IO.iodata_to_binary(msgctxt), key(%Translation{translation | msgctxt: nil})}
+  defp id_key(%Translation{msgid: msgid}),
+    do: IO.iodata_to_binary(msgid)
 
-  def key(%PluralTranslation{msgid: msgid, msgid_plural: msgid_plural, msgctxt: nil}),
+  defp id_key(%PluralTranslation{msgid: msgid, msgid_plural: msgid_plural}),
     do: {IO.iodata_to_binary(msgid), IO.iodata_to_binary(msgid_plural)}
-
-  def key(%PluralTranslation{msgctxt: msgctxt} = translation),
-    do: {IO.iodata_to_binary(msgctxt), key(%PluralTranslation{translation | msgctxt: nil})}
 
   @doc """
   Finds a given translation in a list of translations.

--- a/lib/gettext/po/translations.ex
+++ b/lib/gettext/po/translations.ex
@@ -95,12 +95,21 @@ defmodule Gettext.PO.Translations do
       iex> Gettext.PO.Translations.key(t)
       {"foo", "foos"}
 
+      iex> t = %Gettext.PO.PluralTranslation{msgctxt: "bar", msgid: "foo", msgid_plural: "foos"}
+      iex> Gettext.PO.Translations.key(t)
+      {"bar", {"foo", "foos"}}
   """
-  @spec key(PO.translation()) :: binary | {binary, binary}
-  def key(%Translation{msgid: msgid}), do: IO.iodata_to_binary(msgid)
+  @spec key(PO.translation()) :: binary | {binary, binary} | {binary, {binary, binary}}
+  def key(%Translation{msgid: msgid, msgctxt: nil}), do: IO.iodata_to_binary(msgid)
 
-  def key(%PluralTranslation{msgid: msgid, msgid_plural: msgid_plural}),
+  def key(%Translation{msgctxt: msgctxt} = translation),
+    do: {IO.iodata_to_binary(msgctxt), key(%Translation{translation | msgctxt: nil})}
+
+  def key(%PluralTranslation{msgid: msgid, msgid_plural: msgid_plural, msgctxt: nil}),
     do: {IO.iodata_to_binary(msgid), IO.iodata_to_binary(msgid_plural)}
+
+  def key(%PluralTranslation{msgctxt: msgctxt} = translation),
+    do: {IO.iodata_to_binary(msgctxt), key(%PluralTranslation{translation | msgctxt: nil})}
 
   @doc """
   Finds a given translation in a list of translations.


### PR DESCRIPTION
Often you need to control your translations so adding msgctxt allows you
to have different translations even if you are using the same msgid.

Here we are making sure that this doesn't trip the duplication check.

This is hopefully the last bit for this feature request at least on the parsing side:
https://github.com/elixir-lang/gettext/issues/199