### PR TITLE
Fix a bug when dumping references

### DIFF
--- a/lib/gettext/po.ex
+++ b/lib/gettext/po.ex
@@ -269,24 +269,38 @@ defmodule Gettext.PO do
   defp dump_references(references) do
     # This function outputs a bunch of #: comments with as many references on
     # each line as there can be under @reference_wrapping_column columns.
-    # In the flat_map_reduce, we insert newlines and comment delimiters (#:)
-    # when references wrap, building an iolist. At the end, we need to insert
-    # the first comment delimiter and the last newline.
     wrapping_column = @wrapping_column - @reference_comment_length
 
-    {iolist, _} =
-      Enum.flat_map_reduce(references, 0, fn {file, line}, line_length ->
-        ref = " #{file}:#{line}"
-        ref_length = String.length(ref)
+    references
+    |> chunk_references_by_line(wrapping_column, _line_length = 0, _chunk = [], _acc = [])
+    |> Enum.map(fn line -> ["#:", line, ?\n] end)
+  end
 
-        if ref_length + line_length > wrapping_column do
-          {[?\n, "#:", ref], ref_length}
-        else
-          {[ref], line_length + ref_length}
-        end
-      end)
+  defp chunk_references_by_line([], _wrapping_col, _line_length, _chunk_acc = [], acc) do
+    Enum.reverse(acc)
+  end
 
-    ["#:", iolist, ?\n]
+  defp chunk_references_by_line([], _wrapping_col, _line_length, _chunk_acc = chunk_acc, acc) do
+    acc = [Enum.reverse(chunk_acc) | acc]
+    Enum.reverse(acc)
+  end
+
+  defp chunk_references_by_line([{file, line} | rest], wrapping_col, line_length, chunk_acc, acc) do
+    ref = " #{file}:#{line}"
+    ref_length = String.length(ref)
+
+    cond do
+      ref_length + line_length > wrapping_col and chunk_acc == [] ->
+        chunk_references_by_line(rest, wrapping_col, 0, [ref], acc)
+
+      ref_length + line_length > wrapping_col ->
+        acc = [Enum.reverse(chunk_acc) | acc]
+        chunk_references_by_line(rest, wrapping_col, 0, [ref], acc)
+
+      true ->
+        new_line_length = line_length + ref_length
+        chunk_references_by_line(rest, wrapping_col, new_line_length, [ref | chunk_acc], acc)
+    end
   end
 
   defp dump_flags(flags) do

--- a/test/gettext/po_test.exs
+++ b/test/gettext/po_test.exs
@@ -376,16 +376,17 @@ defmodule Gettext.POTest do
             msgid: ["foo"],
             msgstr: ["bar"],
             references: [
-              {String.duplicate("a", 50) <> ".ex", 1},
-              {String.duplicate("b", 50) <> ".ex", 2}
+              {String.duplicate("a", 30) <> ".ex", 1},
+              {String.duplicate("b", 30) <> ".ex", 1},
+              {String.duplicate("c", 30) <> ".ex", 1}
             ]
           }
         ]
       }
 
       assert IO.iodata_to_binary(PO.dump(po)) == ~S"""
-             #: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ex:1
-             #: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ex:2
+             #: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ex:1 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ex:1
+             #: cccccccccccccccccccccccccccccc.ex:1
              msgid "foo"
              msgstr "bar"
              """


### PR DESCRIPTION
Closes #212.

If the first reference was longer than the whole line length, we
would write an empty "#:" reference comment because of the way that
dumping of reference comments was built. I changed the implementation
so that we chunk references so that each chunk represents a line to
dump, which fixes the problem described above.