### PR TITLE
Improve generation of interpolated clauses

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -480,9 +480,10 @@ defmodule Gettext.Compiler do
       end
 
     clauses =
-      cond do
-        keys == [:count] and translation_type == :plural_translation -> all_bindings_clause
-        true -> all_bindings_clause ++ dynamic_interpolation_clause
+      if keys == [:count] and translation_type == :plural_translation do
+        all_bindings_clause
+      else
+        all_bindings_clause ++ dynamic_interpolation_clause
       end
 
     quote do

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -488,16 +488,6 @@ defmodule Gettext.Compiler do
     quote do
       case var!(bindings), do: unquote(clauses)
     end
-
-    # quote do
-    #   case var!(bindings) do
-    #     unquote(match) ->
-    #       {:ok, unquote(interpolation)}
-
-    #     %{} ->
-    #       Gettext.Interpolation.interpolate(unquote(interpolatable), var!(bindings))
-    #   end
-    # end
   end
 
   # Compiles a list of atoms into a "match" map. For example `[:foo, :bar]` gets


### PR DESCRIPTION
Closes #206.

This PR implements what was suggested by @josevalim in #206. Basically, when we compile a plural translation, if the only interpolation key in the msgstrs is `%{count}` then we know it's gonna be in the bindings because **we** put it there. For this reason, we don't need to have a fallback to dynamically interpolate bindings in those cases and in fact removing the fallback clause fixes a Dialyzer error.

This solution works but we should note that `generated: true` as also suggested by @josevalim in #206 also fixes the Dialyzer warning and keeps the code simpler, but at the cost of potentially hiding other errors/warnings. Wdyt @josevalim, which solution should we go with?