### PR TITLE
 Solve problem with erasing .po after recompile

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -112,17 +112,10 @@ defmodule Mix.Tasks.Gettext.Extract do
   end
 
   defp force_compile do
-    Mix.Tasks.Compile.Elixir.clean()
-    Enum.each(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1)
-
-    # If "compile" was never called, the reenabling is a no-op and
-    # "compile.elixir" is a no-op as well (because it wasn't reenabled after
-    # running "compile"). If "compile" was already called, then running
-    # "compile" is a no-op and running "compile.elixir" will work because we
-    # manually reenabled it.
-    Mix.Task.reenable("compile.elixir")
+    project = Mix.Project.config()
+    dest = Mix.Project.app_path(project)
+    File.rm_rf(dest)
     Mix.Task.run("compile")
-    Mix.Task.run("compile.elixir", ["--force"])
   end
 
   defp run_merge(pot_files, argv) do


### PR DESCRIPTION
I've got a few issues with re-enabling "extract". Some of the .po partly erased. I pretty sure that removing only manifests and cleaning elixir's compile file isn't enough. So I suggest to clean the whole app_path to be ensure that nothing could interrupt extracting. 
I need some time to be perfectly sure it will work, so I leave PR as WIP until that.  